### PR TITLE
support rootnode for for phpcrbrowsertree to be able to show subtrees

### DIFF
--- a/Block/TreeBlockService.php
+++ b/Block/TreeBlockService.php
@@ -37,7 +37,11 @@ class TreeBlockService extends BaseBlockService
      */
     public function execute(BlockInterface $block, Response $response = null)
     {
-        return $this->templating->renderResponse('SonataDoctrinePHPCRAdminBundle:Block:tree.html.twig', array(), $response);
+        $options = array('id' => '/');
+        if (null !== $block->getSettings()) {
+            $options = array_merge($options, $block->getSettings());
+        }
+        return $this->templating->renderResponse('SonataDoctrinePHPCRAdminBundle:Block:tree.html.twig', $options, $response);
     }
 
     /**

--- a/Form/Type/TreeModelType.php
+++ b/Form/Type/TreeModelType.php
@@ -16,6 +16,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormViewInterface;
 use Symfony\Component\Form\FormView;
 
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
@@ -33,6 +34,12 @@ class TreeModelType extends AbstractType
     {
         $builder->prependClientTransformer(new ModelToIdTransformer($options['model_manager'], $options['class']));
         $builder->setAttribute('rootNode', $options['rootNode']);
+    }
+
+    public function buildView(FormViewInterface $view, FormInterface $form, array $options)
+    {
+        parent::buildView($view, $form, $options);
+        $view->setVar('rootNode', $form->getAttribute('rootNode'));
     }
 
     public function setDefaultOptions(OptionsResolverInterface $resolver)

--- a/Resources/views/Block/tree.html.twig
+++ b/Resources/views/Block/tree.html.twig
@@ -1,1 +1,1 @@
-{% render 'SonataDoctrinePHPCRAdminBundle:Tree:tree' with { 'id': app.request.get('id') } %}
+{% render 'SonataDoctrinePHPCRAdminBundle:Tree:tree' with { 'id': id } %}

--- a/Resources/views/Form/form_admin_fields.html.twig
+++ b/Resources/views/Form/form_admin_fields.html.twig
@@ -85,6 +85,7 @@ file that was distributed with this source code.
         var treeState = AdminTree.generateTreeStateArray("{{ id }}");
         SelectTree.initTree({
             "selector": "#{{id}}-tree-selector",
+            "rootNode": "{{ rootNode }}",
             "output": "#{{id}}-tree-selector-output",
             "path": {
                 "expanded":     treeState,

--- a/Resources/views/Tree/tree.html.twig
+++ b/Resources/views/Tree/tree.html.twig
@@ -17,6 +17,7 @@ file that was distributed with this source code.
 
         AdminTree.initTree({
             "selector": "#tree",
+            "rootNode": "{{ id }}",
             "contentselector": ".sonata-ba-content",
             "path": {
                 "expanded":     treeState,


### PR DESCRIPTION
allow the rootnode passed to the select tree and also to the tree block
depends on the PR for the TReeBrowserBundle
