### PR TITLE
javascript tree needs leading slashes in the ids

### DIFF
--- a/Tree/PhpcrOdmTree.php
+++ b/Tree/PhpcrOdmTree.php
@@ -133,7 +133,7 @@ class PhpcrOdmTree implements TreeInterface
         $admin = $this->getAdmin($document);
         if (null !== $admin) {
             $label = $admin->toString($document);
-            $id = $admin->getModelManager()->getNormalizedIdentifier($document);
+            $id = '/' . $admin->getModelManager()->getNormalizedIdentifier($document);
         } else {
             $className = ''; // empty class name means not editable
             $label = '';
@@ -145,7 +145,7 @@ class PhpcrOdmTree implements TreeInterface
                 $label = substr($label, 0, 17) . '...';
             }
             $label .= ' <not editable>';
-            $id = $this->defaultModelManager->getNormalizedIdentifier($document);
+            $id = '/' . $this->defaultModelManager->getNormalizedIdentifier($document);
         }
 
         // TODO: this is not an efficient way to determine if there are children. should ask the phpcr node


### PR DESCRIPTION
the phpcr odm tree returns ids without leading slashes. in order for the tree to work properly we need to stick to the leading slashes. any other nicer solution is welcome ...
