### PR TITLE
Update Model/ModelManager.php

### DIFF
--- a/Model/ModelManager.php
+++ b/Model/ModelManager.php
@@ -304,7 +304,6 @@ class ModelManager implements ModelManagerInterface
      */
     public function addIdentifiersToQuery($class, ProxyQueryInterface $queryProxy, array $idx)
     {
-        $fieldNames = $this->getIdentifierFieldNames($class);
 
         /** @var \PHPCR\Util\QOM\QueryBuilder $qb  */
         $qb = $queryProxy->getQueryBuilder();
@@ -312,15 +311,12 @@ class ModelManager implements ModelManagerInterface
 
         $constraint = null;
         foreach ($idx as $id) {
-            $ids = explode('-', $id);
-            foreach ($fieldNames as $posName => $name) {
-                $path = $this->getBackendId($ids[$posName]);
-                $condition = $qmf->sameNode($path);
-                if ($constraint) {
-                    $constraint = $qmf->orConstraint($constraint, $condition);
-                } else {
-                    $constraint = $condition;
-                }
+            $path = $this->getBackendId($id);
+            $condition = $qmf->sameNode($path);
+            if ($constraint) {
+                $constraint = $qmf->orConstraint($constraint, $condition);
+            } else {
+                $constraint = $condition;
             }
         }
         $qb->andWhere($constraint);


### PR DESCRIPTION
Removed exploding on '-' dash. It's a feature of ORM not ODM. Since the key of every document is expressed at its path.

I found this broken when having a dash in my document path. In CMF this must be always broken for the menuadmin since every menu document must have "-item" in the nodename.
