### PR TITLE
Minor fix to createQuery method

### DIFF
--- a/Model/ModelManager.php
+++ b/Model/ModelManager.php
@@ -206,8 +206,9 @@ class ModelManager implements ModelManagerInterface
      */
     public function createQuery($class, $alias = 'o', $root = null)
     {
-        $queryBuilder = $this->getDocumentManager()->createQueryBuilder();
-        $qomFactory = $queryBuilder->getQOMFactory();
+        $documentManager = $this->getDocumentManager();
+        $queryBuilder = $documentManager->createPhpcrQueryBuilder();
+        $qomFactory = $documentManager->getPhpcrSession()->getWorkspace()->getQueryManager()->getQOMFactory();
         $query = new ProxyQuery($qomFactory, $queryBuilder);
         $query->setDocumentName($class);
         $query->setDocumentManager($this->getDocumentManager());


### PR DESCRIPTION
Sonata Admin "List" pages were broken with the following fatal error:

_Call to undefined method Doctrine\ODM\PHPCR\Query\QueryBuilder::getQOMFactory()_

Have not run tests (can someone explain how I can do this), but tested working in cmf-sandbox project.

Please excuse me if this is not correct etiquette - I'm new to CMF dev.

Gez
