### PR TITLE
Fixed default field mapping from metadata

### DIFF
--- a/Builder/FormContractor.php
+++ b/Builder/FormContractor.php
@@ -49,8 +49,8 @@ class FormContractor implements FormContractorInterface
             $metadata = $admin->getModelManager()->getMetadata($admin->getClass());
             
             // set the default field mapping
-            if (isset($metadata->fieldMappings[$fieldDescription->getName()])) {
-                $fieldDescription->setFieldMapping($metadata->fieldMappings[$fieldDescription->getName()]);
+            if (isset($metadata->mappings[$fieldDescription->getName()])) {
+                $fieldDescription->setFieldMapping($metadata->mappings[$fieldDescription->getName()]);
             }
 
             // set the default association mapping


### PR DESCRIPTION
Not sure where this broke. But the default mapping for fields from metadata got the data from the wrong variable.

This PR fixes it, but I can't really guarantee this doesn't break other things. It works in my case and tests still pass.
