### PR TITLE
Fix Media compatibilty

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "sonata-project/admin-bundle": "2.1.*@dev",
+        "sonata-project/admin-bundle": ">=2.1,<2.3-dev",
         "symfony/framework-bundle": ">=2.1,<2.3-dev",
         "doctrine/phpcr-odm":"1.0.*",
         "doctrine/phpcr-bundle":"1.0.*",


### PR DESCRIPTION
As admin dev master moved to 2.2 we need to stay in 2.1 if we want to 
work with SonataMediaBundle 
which depends on notification 2.1 
which depends on admin 2.1
