### PR TITLE
fixed rendering of the tree for Symfony2.2, minor cleanups

### DIFF
--- a/Controller/TreeController.php
+++ b/Controller/TreeController.php
@@ -3,6 +3,7 @@
 namespace Sonata\DoctrinePHPCRAdminBundle\Controller;
 
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Cmf\Bundle\TreeBrowserBundle\Tree\TreeInterface;
 
@@ -41,16 +42,17 @@ class TreeController extends Controller
      * Renders a tree, passing the routes for each of the admin types (document types)
      * to the view
      *
-     * @param string $root path to the tree root
-     * @param null|string $selected
+     * @param Request $request
      * @return Response
      */
-    public function treeAction($root, $selected = null)
+    public function treeAction(Request $request)
     {
+        $root = $request->query->get('root');
+        $selected = $request->query->get('selected') ?: $root;
         return $this->render($this->template, array(
             'tree' => $this->tree,
             'root_node' => $root,
-            'selected_node' => $selected ?: $root,
+            'selected_node' => $selected,
             'routing_defaults' => $this->defaults,
             'confirm_move' => $this->confirmMove
         ));

--- a/Resources/config/routing/phpcrodmbrowser.xml
+++ b/Resources/config/routing/phpcrodmbrowser.xml
@@ -4,14 +4,10 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
-    <route id="sonata.admin.doctrine_phpcr.phpcrodm_children" pattern="/odm-children">
-        <default key="_controller">sonata.admin.doctrine_phpcr.phpcrodm_controller:childrenAction</default>
+    <!-- TODO: route only exists for Symfony2.1 compat https://github.com/sonata-project/SonataDoctrinePhpcrAdminBundle/issues/86 -->
+    <route id="sonata.admin.doctrine_phpcr.phpcrodm_tree" pattern="/odm-tree">
+        <default key="_controller">sonata.admin.doctrine_phpcr.tree_controller:treeAction</default>
         <requirement key="_method">GET</requirement>
-    </route>
-
-    <route id="sonata.admin.doctrine_phpcr.phpcrodm_move" pattern="/odm-move">
-        <default key="_controller">sonata.admin.doctrine_phpcr.phpcrodm_controller:moveAction</default>
-        <requirement key="_method">POST</requirement>
     </route>
 
 </routes>

--- a/Resources/views/Block/tree.html.twig
+++ b/Resources/views/Block/tree.html.twig
@@ -1,2 +1,3 @@
-<fieldset><legend>{{ 'content_tree' | trans({}, 'SonataDoctrinePHPCRAdmin') }}</fieldset></legend>
-{% render 'sonata.admin.doctrine_phpcr.tree_controller:treeAction' with { 'root': id, 'selected': selected } %}
+<fieldset><legend>{{ 'content_tree' | trans({}, 'SonataDoctrinePHPCRAdmin') }}</legend></fieldset>
+{# TODO: url is only used for Symfony2.1 compat https://github.com/sonata-project/SonataDoctrinePhpcrAdminBundle/issues/86 #}
+{% render url('sonata.admin.doctrine_phpcr.phpcrodm_tree', { 'root': id, 'selected': selected }) %}


### PR DESCRIPTION
this should fix #86 

note you will need to add the following to your `routing.yml`:

```
tree:
    resource: "@SonataDoctrinePHPCRAdminBundle/Resources/config/routing/phpcrodmbrowser.xml"
    prefix: /phpcrodmbrowser
```
