### PR TITLE
child is a one to one mapping

### DIFF
--- a/Resources/views/Form/form_admin_fields.html.twig
+++ b/Resources/views/Form/form_admin_fields.html.twig
@@ -118,7 +118,7 @@ file that was distributed with this source code.
 
 {% block sonata_type_admin_widget %}
     {#admin {{ sonata_admin.field_description.mappingtype }}#}
-    {% if sonata_admin.field_description.mappingtype == 1 %}
+    {% if sonata_admin.field_description.mappingtype == 1 or sonata_admin.field_description.mappingtype == 'child' %}
         {{ block('sonata_admin_orm_one_to_one_widget') }}
     {% elseif sonata_admin.field_description.mappingtype == 2 %}
         {{ block('sonata_admin_orm_many_to_one_widget') }}


### PR DESCRIPTION
allows to embed an admin for a child like:

->add('third_teaser', 'sonata_type_admin', array(), array('admin_code' => 'some_bundle.image_text_block_admin', 'edit' => 'inline'))
