### PR TITLE
automatically apply reorderings to children with sonata-type-collection

### DIFF
--- a/Form/Extension/CollectionTypeExtension.php
+++ b/Form/Extension/CollectionTypeExtension.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Sonata package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrinePHPCRAdminBundle\Form\Extension;
+
+use Doctrine\Common\Util\Debug;
+use Symfony\Component\Form\AbstractTypeExtension;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormEvents;
+
+use Sonata\DoctrinePHPCRAdminBundle\Form\Listener\CollectionOrderListener;
+
+/**
+ * Extend the sonata collection type to sort the collection so the reordering
+ * is automatically persisted in phpcr-odm.
+ */
+class CollectionTypeExtension extends AbstractTypeExtension
+{
+
+    /**
+     * {@inheritDoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $listener = new CollectionOrderListener($options['sonata_field_description']->getName());
+        $builder->getParent()->addEventListener(FormEvents::BIND, array($listener, 'onPostBind'));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getExtendedType()
+    {
+        return 'sonata_type_collection';
+    }
+}

--- a/Form/Listener/CollectionOrderListener.php
+++ b/Form/Listener/CollectionOrderListener.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the Sonata package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrinePHPCRAdminBundle\Form\Listener;
+
+use Doctrine\Common\Util\Debug;
+use Doctrine\ODM\PHPCR\ChildrenCollection;
+use Symfony\Component\Form\FormEvent;
+
+/**
+ * A listener for the parent form object to reorder a children collection based
+ * on the order in the form request, which reflects the frontend order. Just
+ * setting the right order will make PHPCR-ODM persist the reorderings.
+ *
+ * @author David Buchmann <david@liip.ch>
+ */
+class CollectionOrderListener
+{
+    private $name;
+
+    /**
+     * @param string $name the form field name used for the collection
+     */
+    public function __construct($name)
+    {
+        $this->name = $name;
+    }
+
+    /**
+     * Reorder the children at $this->name
+     *
+     * @param FormEvent $event
+     */
+    public function onPostBind(FormEvent $event)
+    {
+        /** @var $newCollection ChildrenCollection */
+        $newCollection = $event->getData()->getChildren();
+
+        $newCollection->clear();
+        foreach ($event->getForm()->get($this->name) as $item) {
+            if ($item->get('_delete')->getData()) {
+                // do not re-add a deleted child
+                continue;
+            }
+            if ($item->getName()) {
+                // keep key in collection
+                $newCollection[$item->getName()] = $item->getData();
+            } else {
+                $newCollection[] = $item->getData();
+            }
+        }
+    }
+}

--- a/Resources/config/doctrine_phpcr_odm_form_types.xml
+++ b/Resources/config/doctrine_phpcr_odm_form_types.xml
@@ -18,6 +18,11 @@
         <service id="sonata.admin.doctrine_phpcr.form.type.tree_manager" class="Sonata\DoctrinePHPCRAdminBundle\Form\Type\TreeManagerType">
             <tag name="form.type" alias="doctrine_phpcr_odm_tree_manager" />
         </service>
+
+        <service id="sonata.admin.doctrine_phpcr.form.collection_type_extension" class="Sonata\DoctrinePHPCRAdminBundle\Form\Extension\CollectionTypeExtension"
+                >
+            <tag name="form.type_extension" alias="sonata_type_collection" />
+        </service>
     </services>
 
 </container>


### PR DESCRIPTION
adding a form type extension to make sonata-type-collection reorder automatically so reorderings need no further handling
