### PR TITLE
added condition so only the type_collection for phpcr admins gets extended

### DIFF
--- a/Form/Extension/CollectionTypeExtension.php
+++ b/Form/Extension/CollectionTypeExtension.php
@@ -29,7 +29,7 @@ class CollectionTypeExtension extends AbstractTypeExtension
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        if (! $options['sonata_field_description']->getOption('sortable')) {
+        if ('doctrine_phpcr' != $options['sonata_field_description']->getAdmin()->getManagerType() || ! $options['sonata_field_description']->getOption('sortable')) {
             return;
         }
         $listener = new CollectionOrderListener($options['sonata_field_description']->getName());


### PR DESCRIPTION
If you have an ORM admin with a sonata_type_collection field and the SonataDoctrinePhpcrAdminBundle is also registered the CollectionTypeExtension will throw an error because it tries to add the CollectionOrderListener to an ORM admin. The extra condition solves this.
