### PR TITLE
fix root path to use a unique name instead of hiding admin root as defined by base sonata admin

### DIFF
--- a/Admin/Admin.php
+++ b/Admin/Admin.php
@@ -22,15 +22,29 @@ use Sonata\AdminBundle\Route\RouteCollection;
 class Admin extends BaseAdmin
 {
     /**
-     * Path to the root node of simple pages.
+     * Path to the root node of documents for this admin.
      *
      * @var string
      */
-    protected $root;
+    private $rootPath;
 
-    public function setRoot($root)
+    /**
+     * Set the root path in the repository. To be able to create new items,
+     * this path must already exist.
+     *
+     * @param string $rootPath
+     */
+    public function setRootPath($rootPath)
     {
-        $this->root = $root;
+        $this->rootPath = $rootPath;
+    }
+
+    /**
+     * @return string
+     */
+    public function getRootPath()
+    {
+        return $this->rootPath;
     }
 
     /**
@@ -38,7 +52,7 @@ class Admin extends BaseAdmin
      */
     public function createQuery($context = 'list')
     {
-        $query = $this->getModelManager()->createQuery($this->getClass(), '', $this->root);
+        $query = $this->getModelManager()->createQuery($this->getClass(), '', $this->getRootPath());
 
         foreach ($this->extensions as $extension) {
             $extension->configureQuery($this, $query, $context);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | yes (currently used in SimpleCmsBundle) |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |

This was duplicated in all the bundles providing admins, except for SimpleCms. The name root is already used by base sonata admin.
