### PR TITLE
use PropertyAccess instead of straight reflection

### DIFF
--- a/Tree/PhpcrOdmTree.php
+++ b/Tree/PhpcrOdmTree.php
@@ -5,6 +5,7 @@ namespace Sonata\DoctrinePHPCRAdminBundle\Tree;
 use PHPCR\Util\NodeHelper;
 
 use PHPCR\Util\PathHelper;
+use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\Translation\TranslatorInterface;
 use Symfony\Component\Templating\Helper\CoreAssetsHelper;
 use Symfony\Cmf\Bundle\TreeBrowserBundle\Tree\TreeInterface;
@@ -218,6 +219,7 @@ class PhpcrOdmTree implements TreeInterface
      */
     private function getDocumentChildren($document)
     {
+        $accessor = PropertyAccess::getPropertyAccessor(); // use deprecated BC method to support symfony 2.2
         $admin = $this->getAdmin($document);
         $manager = null !== $admin ? $admin->getModelManager() : $this->defaultModelManager;
 
@@ -226,18 +228,27 @@ class PhpcrOdmTree implements TreeInterface
 
         $children = array();
         foreach ($meta->childrenMappings as $fieldName) {
-            $prop = $meta->getReflectionProperty($fieldName)->getValue($document);
+            $prop = $accessor->getValue($document, $fieldName);
+            if (null === $prop) {
+                // if there was no method, try reflection as a last resort
+                $prop = $meta->getReflectionProperty($fieldName)->getValue($document);
+            }
             if (null === $prop) {
                 continue;
             }
             if (!is_array($prop)) {
                 $prop = $prop->toArray();
             }
+
             $children = array_merge($children, $this->filterDocumentChildren($document, $prop));
         }
 
         foreach ($meta->childMappings as $fieldName) {
-            $prop = $meta->getReflectionProperty($fieldName)->getValue($document);
+            $prop = $accessor->getValue($document, $fieldName);
+            if (null === $prop) {
+                // if there was no method, try reflection as a last resort
+                $prop = $meta->getReflectionProperty($fieldName)->getValue($document);
+            }
             if (null !== $prop && $this->isValidDocumentChild($document, $prop)) {
                 $children[$fieldName] = $prop;
             }


### PR DESCRIPTION
this is not only cleaner and more safe, it also avoids issues with reflection not triggering the doctrine proxy to populate.

this is adding no new dependency, we already depend on PropertyAccess.
