### PR TITLE
Fix permission validation bug for sonata admin types

### DIFF
--- a/Resources/views/CRUD/edit_phpcr_many_to_one.html.twig
+++ b/Resources/views/CRUD/edit_phpcr_many_to_one.html.twig
@@ -64,7 +64,7 @@ file that was distributed with this source code.
                 </a>
             {% endif %}
 
-            {% if sonata_admin.edit == 'list' and sonata_admin.field_description.associationadmin.hasRoute('list') and sonata_admin.field_description.associationadmin.isGranted('LIST') %}
+            {% if sonata_admin.field_description.associationadmin.hasRoute('delete') and sonata_admin.field_description.associationadmin.isGranted('DELETE') %}
                 <a  href=""
                     onclick="remove_selected_element_{{ id }}(event)"
                     class="btn sonata-ba-action"

--- a/Resources/views/CRUD/edit_phpcr_one_to_one.html.twig
+++ b/Resources/views/CRUD/edit_phpcr_one_to_one.html.twig
@@ -64,7 +64,7 @@ file that was distributed with this source code.
                 </a>
             {% endif %}
 
-            {% if sonata_admin.edit == 'list' and sonata_admin.field_description.associationadmin.hasRoute('list') and sonata_admin.field_description.associationadmin.isGranted('LIST') %}
+            {% if sonata_admin.field_description.associationadmin.hasRoute('delete') and sonata_admin.field_description.associationadmin.isGranted('DELETE') %}
                 <a  href=""
                     onclick="remove_selected_element_{{ id }}(event)"
                     class="btn sonata-ba-action"


### PR DESCRIPTION
The current permission validation for deletion in sonata admin types is bugged, as 'list' permissions are being checked, not 'delete'

Already discussed as part of https://github.com/sonata-project/SonataDoctrinePhpcrAdminBundle/pull/163
