### PR TITLE
Add try/catch block to children access to avoid issue with Route handling

### DIFF
--- a/Tree/PhpcrOdmTree.php
+++ b/Tree/PhpcrOdmTree.php
@@ -252,9 +252,9 @@ class PhpcrOdmTree implements TreeInterface
         }
 
         foreach ($meta->childMappings as $fieldName) {
-            $prop = $accessor->getValue($document, $fieldName);
-            if (null === $prop) {
-                // if there was no method, try reflection as a last resort
+            try {
+                $prop = $accessor->getValue($document, $fieldName);
+            } catch (NoSuchPropertyException $e) {
                 $prop = $meta->getReflectionProperty($fieldName)->getValue($document);
             }
             if (null !== $prop && $this->isValidDocumentChild($document, $prop)) {


### PR DESCRIPTION
Right now the Route class has a children property that is protected. This causes an exception to be thrown by the PropertyAccessor component. This change catches that exception and falls back to using reflection.
