### PR TITLE
Expand the special 'all' value to a full array of doc types

### DIFF
--- a/DependencyInjection/SonataDoctrinePHPCRAdminExtension.php
+++ b/DependencyInjection/SonataDoctrinePHPCRAdminExtension.php
@@ -108,7 +108,29 @@ class SonataDoctrinePHPCRAdminExtension extends Extension
         $container->setParameter('sonata_admin_doctrine_phpcr.tree_block.defaults', $config['document_tree_defaults']);
         $container->setParameter('sonata_admin_doctrine_phpcr.tree_confirm_move', $config['confirm_move']);
         $container->getDefinition('sonata.admin.doctrine_phpcr.phpcr_odm_tree')
-            ->replaceArgument(5, $config['document_tree']);
+            ->replaceArgument(5, $this->normalizeDocumentTree($config['document_tree']));
     }
+
+    /**
+     * Normalize the document tree config, replacing references to 'all' with an array of all registered types
+     * 
+     * @param array $documentTree 
+     */
+    private function normalizeDocumentTree(array $documentTree)
+    {
+        $docTypes = array_keys($documentTree);
+
+        $normalized = array();
+        foreach ($documentTree as $docType => $config) {
+            if (count($config['valid_children']) === 1 && $config['valid_children'][0] === 'all') {
+                $config['valid_children'] = $docTypes;
+            }
+            $normalized[$docType] = $config;
+        }
+
+        return $normalized;
+    }
+}
+
 }
 


### PR DESCRIPTION
This is a fix for the following issue:
https://github.com/symfony-cmf/TreeBrowserBundle/issues/46#issuecomment-24631933
