### PR TITLE
Refactored tests in Tests/Filter in conformance to the renaming selectorName,propertyName => alias,field

### DIFF
--- a/Tests/Filter/BooleanFilterTest.php
+++ b/Tests/Filter/BooleanFilterTest.php
@@ -76,8 +76,8 @@ class BooleanFilterTest extends BaseTestCase
         $opDynamic = $this->qbTester->getNode('where.constraint.operand_dynamic');
         $opStatic = $this->qbTester->getNode('where.constraint.operand_static');
 
-        $this->assertEquals('a', $opDynamic->getSelectorName());
-        $this->assertEquals('somefield', $opDynamic->getPropertyName());
+        $this->assertEquals('a', $opDynamic->getAlias());
+        $this->assertEquals('somefield', $opDynamic->getField());
         $this->assertEquals($expectedValue, $opStatic->getValue());
 
         $this->assertTrue($this->filter->isActive());

--- a/Tests/Filter/CallBackFilterTest.php
+++ b/Tests/Filter/CallBackFilterTest.php
@@ -51,8 +51,8 @@ class CallbackFilterTest extends BaseTestCase
         $opDynamic = $this->qbTester->getNode('where.constraint.operand_dynamic');
         $opStatic = $this->qbTester->getNode('where.constraint.operand_static');
 
-        $this->assertEquals('a', $opDynamic->getSelectorName());
-        $this->assertEquals('somefield', $opDynamic->getPropertyName());
+        $this->assertEquals('a', $opDynamic->getAlias());
+        $this->assertEquals('somefield', $opDynamic->getField());
         $this->assertEquals('somevalue', $opStatic->getValue());
 
         $this->assertTrue($filter->isActive());
@@ -86,8 +86,8 @@ class CallbackFilterTest extends BaseTestCase
         $opDynamic = $this->qbTester->getNode('where.constraint.operand_dynamic');
         $opStatic = $this->qbTester->getNode('where.constraint.operand_static');
 
-        $this->assertEquals('a', $opDynamic->getSelectorName());
-        $this->assertEquals('somefield', $opDynamic->getPropertyName());
+        $this->assertEquals('a', $opDynamic->getAlias());
+        $this->assertEquals('somefield', $opDynamic->getField());
         $this->assertEquals('somevalue', $opStatic->getValue());
 
         $this->assertTrue($filter->isActive());

--- a/Tests/Filter/ChoiceFilterTest.php
+++ b/Tests/Filter/ChoiceFilterTest.php
@@ -100,8 +100,8 @@ class ChoiceFilterTest extends BaseTestCase
                 'qbNodeCount' => 6,
                 'assertPaths' => array(
                     'where.constraint.constraint[0].constraint.operand_dynamic' => array(
-                        'getSelectorName' => 'a',
-                        'getPropertyName' => 'somefield',
+                        'getAlias' => 'a',
+                        'getField' => 'somefield',
                     ),
                     'where.constraint.constraint[0].constraint.operand_static' => array(
                         'getValue' => '%somevalue%',
@@ -114,15 +114,15 @@ class ChoiceFilterTest extends BaseTestCase
                 'qbNodeCount' => 10,
                 'assertPaths' => array(
                     'where.constraint.constraint.constraint.operand_dynamic' => array(
-                        'getSelectorName' => 'a',
-                        'getPropertyName' => 'somefield',
+                        'getAlias' => 'a',
+                        'getField' => 'somefield',
                     ),
                     'where.constraint.constraint.constraint.operand_static' => array(
                         'getValue' => '%somevalue%',
                     ),
                     'where.constraint.constraint[1].constraint.operand_dynamic' => array(
-                        'getSelectorName' => 'a',
-                        'getPropertyName' => 'somefield',
+                        'getAlias' => 'a',
+                        'getField' => 'somefield',
                     ),
                     'where.constraint.constraint[1].constraint.operand_static' => array(
                         'getValue' => '%somevalue%',
@@ -135,8 +135,8 @@ class ChoiceFilterTest extends BaseTestCase
                 'qbNodeCount' => 5,
                 'assertPaths' => array(
                     'where.constraint.constraint.operand_dynamic' => array(
-                        'getSelectorName' => 'a',
-                        'getPropertyName' => 'somefield',
+                        'getAlias' => 'a',
+                        'getField' => 'somefield',
                     ),
                     'where.constraint.constraint.operand_static' => array(
                         'getValue' => '%somevalue%',
@@ -152,15 +152,15 @@ class ChoiceFilterTest extends BaseTestCase
                 'qbNodeCount' => 8,
                 'assertPaths' => array(
                     'where.constraint.constraint.operand_dynamic' => array(
-                        'getSelectorName' => 'a',
-                        'getPropertyName' => 'somefield',
+                        'getAlias' => 'a',
+                        'getField' => 'somefield',
                     ),
                     'where.constraint.constraint.operand_static' => array(
                         'getValue' => '%somevalue%',
                     ),
                     'where.constraint.constraint[1].operand_dynamic' => array(
-                        'getSelectorName' => 'a',
-                        'getPropertyName' => 'somefield',
+                        'getAlias' => 'a',
+                        'getField' => 'somefield',
                     ),
                     'where.constraint.constraint[1].operand_static' => array(
                         'getValue' => '%somevalue%',
@@ -173,8 +173,8 @@ class ChoiceFilterTest extends BaseTestCase
                 'qbNodeCount' => 5,
                 'assertPaths' => array(
                     'where.constraint.constraint.operand_dynamic' => array(
-                        'getSelectorName' => 'a',
-                        'getPropertyName' => 'somefield',
+                        'getAlias' => 'a',
+                        'getField' => 'somefield',
                     ),
                     'where.constraint.constraint.operand_static' => array(
                         'getValue' => '%somevalue%',
@@ -190,15 +190,15 @@ class ChoiceFilterTest extends BaseTestCase
                 'qbNodeCount' => 8,
                 'assertPaths' => array(
                     'where.constraint.constraint.operand_dynamic' => array(
-                        'getSelectorName' => 'a',
-                        'getPropertyName' => 'somefield',
+                        'getAlias' => 'a',
+                        'getField' => 'somefield',
                     ),
                     'where.constraint.constraint.operand_static' => array(
                         'getValue' => '%somevalue%',
                     ),
                     'where.constraint.constraint[1].operand_dynamic' => array(
-                        'getSelectorName' => 'a',
-                        'getPropertyName' => 'somefield',
+                        'getAlias' => 'a',
+                        'getField' => 'somefield',
                     ),
                     'where.constraint.constraint[1].operand_static' => array(
                         'getValue' => '%somevalue%',
@@ -211,8 +211,8 @@ class ChoiceFilterTest extends BaseTestCase
                 'qbNodeCount' => 5,
                 'assertPaths' => array(
                     'where.constraint.constraint.operand_dynamic' => array(
-                        'getSelectorName' => 'a',
-                        'getPropertyName' => 'somefield',
+                        'getAlias' => 'a',
+                        'getField' => 'somefield',
                     ),
                     'where.constraint.constraint.operand_static' => array(
                         'getValue' => 'somevalue',
@@ -228,15 +228,15 @@ class ChoiceFilterTest extends BaseTestCase
                 'qbNodeCount' => 8,
                 'assertPaths' => array(
                     'where.constraint.constraint.operand_dynamic' => array(
-                        'getSelectorName' => 'a',
-                        'getPropertyName' => 'somefield',
+                        'getAlias' => 'a',
+                        'getField' => 'somefield',
                     ),
                     'where.constraint.constraint.operand_static' => array(
                         'getValue' => 'somevalue',
                     ),
                     'where.constraint.constraint[1].operand_dynamic' => array(
-                        'getSelectorName' => 'a',
-                        'getPropertyName' => 'somefield',
+                        'getAlias' => 'a',
+                        'getField' => 'somefield',
                     ),
                     'where.constraint.constraint[1].operand_static' => array(
                         'getValue' => 'somevalue',

--- a/Tests/Filter/DateFilterTest.php
+++ b/Tests/Filter/DateFilterTest.php
@@ -73,8 +73,8 @@ class DateFilterTest extends BaseTestCase
         $opDynamic = $this->qbTester->getNode('where.constraint.operand_dynamic');
         $opStatic = $this->qbTester->getNode('where.constraint.operand_static');
 
-        $this->assertEquals('a', $opDynamic->getSelectorName());
-        $this->assertEquals('somefield', $opDynamic->getPropertyName());
+        $this->assertEquals('a', $opDynamic->getAlias());
+        $this->assertEquals('somefield', $opDynamic->getField());
         $this->assertEquals($expectedValue, $opStatic->getValue());
 
         $this->assertTrue($this->filter->isActive());
@@ -98,8 +98,8 @@ class DateFilterTest extends BaseTestCase
         $opStatic = $this->qbTester->getNode(
             'where.constraint.constraint.operand_static');
 
-        $this->assertEquals('a', $opDynamic->getSelectorName());
-        $this->assertEquals('somefield', $opDynamic->getPropertyName());
+        $this->assertEquals('a', $opDynamic->getAlias());
+        $this->assertEquals('somefield', $opDynamic->getField());
         $this->assertEquals($from, $opStatic->getValue());
 
         // TO
@@ -108,8 +108,8 @@ class DateFilterTest extends BaseTestCase
         $opStatic = $this->qbTester->getNode(
             'where.constraint.constraint[1].operand_static');
 
-        $this->assertEquals('a', $opDynamic->getSelectorName());
-        $this->assertEquals('somefield', $opDynamic->getPropertyName());
+        $this->assertEquals('a', $opDynamic->getAlias());
+        $this->assertEquals('somefield', $opDynamic->getField());
         $this->assertEquals($to, $opStatic->getValue());
 
         $this->assertTrue($this->filter->isActive());

--- a/Tests/Filter/NodeNameFilterTest.php
+++ b/Tests/Filter/NodeNameFilterTest.php
@@ -86,7 +86,7 @@ class NodeNameFilterTest extends BaseTestCase
         $localName = $this->qbTester->getNode('where.constraint.operand_dynamic');
         $literal = $this->qbTester->getNode('where.constraint.operand_static');
 
-        $this->assertEquals('a', $localName->getSelectorName());
+        $this->assertEquals('a', $localName->getAlias());
         $this->assertEquals($expectedValue, $literal->getValue());
 
         $this->assertTrue($this->filter->isActive());

--- a/Tests/Filter/NumberFilterTest.php
+++ b/Tests/Filter/NumberFilterTest.php
@@ -79,8 +79,8 @@ class NumberFilterTest extends BaseTestCase
         $opDynamic = $this->qbTester->getNode('where.constraint.operand_dynamic');
         $opStatic = $this->qbTester->getNode('where.constraint.operand_static');
 
-        $this->assertEquals('a', $opDynamic->getSelectorName());
-        $this->assertEquals('somefield', $opDynamic->getPropertyName());
+        $this->assertEquals('a', $opDynamic->getAlias());
+        $this->assertEquals('somefield', $opDynamic->getField());
         $this->assertEquals($expectedValue, $opStatic->getValue());
 
         $this->assertTrue($this->filter->isActive());

--- a/Tests/Filter/StringFilterTest.php
+++ b/Tests/Filter/StringFilterTest.php
@@ -57,8 +57,8 @@ class StringFilterTest extends BaseTestCase
         return array(
             array(ChoiceType::TYPE_EQUAL, array(
                 'where.constraint.operand_dynamic' => array(
-                    'getSelectorName' => 'a',
-                    'getPropertyName' => 'somefield',
+                    'getAlias' => 'a',
+                    'getField' => 'somefield',
                 ),
                 'where.constraint.operand_static' => array(
                     'getValue' => 'somevalue',
@@ -66,13 +66,13 @@ class StringFilterTest extends BaseTestCase
             )),
             array(ChoiceType::TYPE_NOT_CONTAINS, array(
                 'where.constraint' => array(
-                    'getPropertyName' => 'somefield',
+                    'getField' => 'somefield',
                     'getFullTextSearchExpression' => '* -somevalue'),
             )),
             array(ChoiceType::TYPE_CONTAINS, array(
                 'where.constraint.operand_dynamic' => array(
-                    'getSelectorName' => 'a',
-                    'getPropertyName' => 'somefield',
+                    'getAlias' => 'a',
+                    'getField' => 'somefield',
                 ),
                 'where.constraint.operand_static' => array(
                     'getValue' => '%somevalue%',
@@ -80,7 +80,7 @@ class StringFilterTest extends BaseTestCase
             )),
             array(ChoiceType::TYPE_CONTAINS_WORDS, array(
                 'where.constraint' => array(
-                    'getPropertyName' => 'somefield',
+                    'getField' => 'somefield',
                     'getFullTextSearchExpression' => 'somevalue'),
             )),
         );


### PR DESCRIPTION
The renaming selectorName,propertyName => alias,field took place in https://github.com/dantleech/phpcr-odm/commit/f460b2da14d89c6d37f082009068069d66aae460
