### PR TITLE
Model\ModelManager::createQuery must be called with a non empty string

### DIFF
--- a/Admin/Admin.php
+++ b/Admin/Admin.php
@@ -53,7 +53,7 @@ class Admin extends BaseAdmin
      */
     public function createQuery($context = 'list')
     {
-        $query = $this->getModelManager()->createQuery($this->getClass(), '', $this->getRootPath());
+        $query = $this->getModelManager()->createQuery($this->getClass(), 'a', $this->getRootPath());
 
         foreach ($this->extensions as $extension) {
             $extension->configureQuery($this, $query, $context);

--- a/Model/ModelManager.php
+++ b/Model/ModelManager.php
@@ -211,9 +211,15 @@ class ModelManager implements ModelManagerInterface
      * @param string $alias (provided only for compatibility with the interface TODO: remove)
      * @param string $root
      * @return \PHPCR\Query\QueryManagerInterface
+     *
+     * @throws \InvalidArgumentException if alias is not a string or an empty string
      */
     public function createQuery($class, $alias = 'a', $root = null)
     {
+        if (!is_string($alias) || '' === $alias) {
+            throw new \InvalidArgumentException('$alias must be a non empty string');
+        }
+
         $qb = $this->getDocumentManager()->createQueryBuilder();
         $qb->from()->document($class, $alias);
         if ($root) {


### PR DESCRIPTION
Enforces non empty string for $alias (and in this particular case, we need an 'a').
