### PR TITLE
fix the *_to_one edit templates to work with sf 2.3 and fix a typo in json

### DIFF
--- a/Resources/views/CRUD/edit_phpcr_many_to_one.html.twig
+++ b/Resources/views/CRUD/edit_phpcr_many_to_one.html.twig
@@ -20,13 +20,13 @@ file that was distributed with this source code.
         {% if sonata_admin.edit == 'list' %}
             <span id="field_widget_{{ id }}" >
                 {% if sonata_admin.admin.id(sonata_admin.value) %}
-                    {% render 'SonataAdminBundle:Helper:getShortObjectDescription' with {}, {
+                    {% render(controller('sonata.admin.controller.admin:getShortObjectDescriptionAction', {
                         'query': {
                             'code':     sonata_admin.field_description.associationadmin.code,
                             'objectId': sonata_admin.field_description.associationadmin.id(sonata_admin.value),
                             'uniqid':   sonata_admin.field_description.associationadmin.uniqid
                         }
-                    }%}
+                    }))%}
                 {% elseif sonata_admin.field_description.options.placeholder is defined and sonata_admin.field_description.options.placeholder %}
                     <span class="inner-field-short-description">
                         {{ sonata_admin.field_description.options.placeholder|trans({}, 'SonataAdminBundle') }}

--- a/Resources/views/CRUD/edit_phpcr_one_to_one.html.twig
+++ b/Resources/views/CRUD/edit_phpcr_one_to_one.html.twig
@@ -20,13 +20,13 @@ file that was distributed with this source code.
         {% if sonata_admin.edit == 'list' %}
             <span id="field_widget_{{ id }}" >
                 {% if sonata_admin.field_description.associationadmin.id(sonata_admin.value) %}
-                    {% render 'SonataAdminBundle:Helper:getShortObjectDescription' with {}, {
+                    {% render(controller('sonata.admin.controller.admin:getShortObjectDescriptionAction', {
                         'query': {
                             'code':     sonata_admin.field_description.associationadmin.code,
                             'objectId': sonata_admin.field_description.associationadmin.id(sonata_admin.value),
                             'uniqid':   sonata_admin.field_description.associationadmin.uniqid
                         }
-                    }%}
+                    }))%}
                 {% elseif sonata_admin.field_description.options.placeholder is defined and sonata_admin.field_description.options.placeholder %}
                     <span class="inner-field-short-description">
                         {{ sonata_admin.field_description.options.placeholder|trans({}, 'SonataAdminBundle') }}

--- a/Resources/views/Form/form_admin_fields.html.twig
+++ b/Resources/views/Form/form_admin_fields.html.twig
@@ -154,7 +154,7 @@ file that was distributed with this source code.
             "selector": "#{{id}}-tree-selector",
             "rootNode": "{{ root_node }}",
             "ajax": {
-                "children_url": Routing.generate("_cmf_tree_{{ tree.alias }}_children", defaults),
+                "children_url": Routing.generate("_cmf_tree_{{ tree.alias }}_children", defaults)
             },
             "output": "#{{id}}-tree-selector-output",
             "reset": "#{{id}}-tree-reset",


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | see travis |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

this is fixing the many_to_one and one_to_one form types to actually work with symfony 2.3. one_to_one is used with the sonata_type_admin form type.
