### PR TITLE
make choice_field_mask work in embedded admin as well

### DIFF
--- a/Resources/views/Form/form_admin_fields.html.twig
+++ b/Resources/views/Form/form_admin_fields.html.twig
@@ -189,14 +189,14 @@ file that was distributed with this source code.
 
 {% block choice_field_mask_widget %}
     {{ block('choice_widget') }}
-    {% set main_form_name = form.parent.vars.name %}
+    {% set main_form_name = id|slice(0, id|length - name|length) %}
 
     <script type="text/javascript">
         $(document).ready(function() {
             var allFields = {{ all_fields|json_encode|raw }};
             var map = {{ map|json_encode|raw }};
 
-            showMaskChoiceEl = $('#{{ main_form_name }}_{{ name }}');
+            showMaskChoiceEl = $('#{{ main_form_name }}{{ name }}');
             showMaskChoiceEl.on('change', function () {
                 choice_field_mask_show($(this).val());
             });
@@ -204,7 +204,7 @@ file that was distributed with this source code.
             function choice_field_mask_show(val)
             {
                 var controlGroupIdFunc = function (field) {
-                    return '#sonata-ba-field-container-{{ main_form_name }}_' + field;
+                    return '#sonata-ba-field-container-{{ main_form_name }}' + field;
                 };
 
                 if (map[val] == undefined) {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Until now, this special form type only worked on stand alone admins, but not in embedded admins as created by sonata_type_collection
