### PR TITLE
one-to-many should render the labels along with form widgets

### DIFF
--- a/Resources/views/CRUD/edit_phpcr_one_to_many.html.twig
+++ b/Resources/views/CRUD/edit_phpcr_one_to_many.html.twig
@@ -63,13 +63,13 @@ file that was distributed with this source code.
                         {% for nested_group_field_name, nested_group_field in form.children %}
                             {% for field_name, nested_field in nested_group_field.children %}
                                 {% if sonata_admin.field_description.associationadmin.formfielddescriptions[field_name] is defined %}
-                                    {{ form_widget(nested_field, {
+                                    {{ form_row(nested_field, {
                                         'inline': 'natural',
                                         'edit'  : 'inline'
                                     }) }}
                                     {% set dummy = nested_group_field.setrendered %}
                                 {% else %}
-                                    {{ form_widget(nested_field) }}
+                                    {{ form_row(nested_field) }}
                                 {% endif %}
                             {% endfor %}
                         {% endfor %}


### PR DESCRIPTION
I use a form type like this with inline type "standard":

```
        ->with('Challenges')
            ->add(
                'challenges',
                'sonata_type_collection',
                array(),
                array(
                    'edit' => 'inline',
                    'inline' => 'standard',
                    'admin_code' => 'acme_blocks.block.testimonial.admin',
            ))
        ->end()
```

this ends up rendering without any labels whatsoever. i don't get how that could be useable for anybody

![broken](https://f.cloud.github.com/assets/76576/1519895/1db71f44-4b6f-11e3-9f47-bd394020df5a.png)

if i do form_row instead, it looks nice.

![fixed](https://f.cloud.github.com/assets/76576/1519894/1644a524-4b6f-11e3-8763-0d5dbbe97125.png)

but the corresponding orm_many_to_one template also is using form_widget only, so i wonder what is going wrong here. @rande any chance you can help me understand what was supposed to happen and how the orm looks in a similar scenario?
