### PR TITLE
Add translation for "Not editable" message

### DIFF
--- a/Resources/translations/SonataDoctrinePHPCRAdmin.en.xliff
+++ b/Resources/translations/SonataDoctrinePHPCRAdmin.en.xliff
@@ -26,6 +26,10 @@
                 <source>list_results_count_prefix</source>
                 <target>at least</target>
             </trans-unit>
+            <trans-unit id="tree_not_editable">
+                <source>not_editable</source>
+                <target>(not editable)</target>
+            </trans-unit>
         </body>
      </file>
 </xliff>


### PR DESCRIPTION
Hello,
Following to the pull request (https://github.com/sonata-project/SonataDoctrinePhpcrAdminBundle/pull/221), this is the translation for the not editable message.
Regards,
