### PR TITLE
drop substr in the tree builder, its the frontends job

### DIFF
--- a/Resources/public/css/layout.css
+++ b/Resources/public/css/layout.css
@@ -1,3 +1,0 @@
-#phpcr_sab_content {
-    margin-left: 240px;
-}

--- a/Tree/PhpcrOdmTree.php
+++ b/Tree/PhpcrOdmTree.php
@@ -207,17 +207,14 @@ class PhpcrOdmTree implements TreeInterface
             $label = PathHelper::getNodeName($label);
         }
 
-        // TODO: this is really the responsibility of the UI
-        if (strlen($label) > 18) {
-            $label = substr($label, 0, 17) . '...';
-        }
-
         // TODO: ideally the tree should simply not make the node clickable
         $label .= $admin ? '' : ' '.$this->translator->trans('not_editable', array(), 'SonataDoctrinePHPCRAdmin');
 
-        // as long as we filter out invalid documents, we need to pass through this logic as a PHPCR node might have children but only invalid ones.
-        // this is quite costly, using the PHPCR node would be a lot more efficient
-        $hasChildren = (bool)count($this->getDocumentChildren($manager, $document));
+        // as long as we filter out invalid documents, we need to pass through
+        // this logic as a PHPCR node might have children but only invalid ones.
+        // this is quite costly. if we would not have to filter, we could simply
+        // use $manager->getDocumentManager()->getNodeForDocument($document)->hasNodes()
+        $hasChildren = (bool) count($this->getDocumentChildren($manager, $document));
 
         return array(
             'data'  => $label,

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "symfony/property-access": "~2.2",
         "doctrine/phpcr-odm":"1.*",
         "doctrine/phpcr-bundle":"1.*",
-        "symfony-cmf/tree-browser-bundle": ">=1.0.0,<1.2.0"
+        "symfony-cmf/tree-browser-bundle": ">=1.1.0,<1.2.0"
     },
     "require-dev": {
         "jackalope/jackalope-jackrabbit": "dev-master"


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | - |
| Fixed tickets | #223 |
| License | MIT |
| Doc PR | - |

alternative to #223 by @ivan1986 . this depends on https://github.com/symfony-cmf/TreeBrowserBundle/pull/55
