### PR TITLE
allow tree with many elements

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -40,6 +40,8 @@ class Configuration implements ConfigurationInterface
             ->children()
                 ->integerNode('depth')->defaultValue(1)->end()
 
+                ->booleanNode('fetch_lazy')->defaultValue(false)->end()
+
                 ->arrayNode('document_tree_defaults')
                     ->prototype('scalar')->end()
                 ->end()

--- a/DependencyInjection/SonataDoctrinePHPCRAdminExtension.php
+++ b/DependencyInjection/SonataDoctrinePHPCRAdminExtension.php
@@ -82,6 +82,8 @@ class SonataDoctrinePHPCRAdminExtension extends AbstractSonataAdminExtension
             ->replaceArgument(5, $this->processDocumentTreeConfig($config['document_tree']));
         $container->getDefinition('sonata.admin.doctrine_phpcr.phpcr_odm_tree')
             ->replaceArgument(6, $config['depth']);
+        $container->getDefinition('sonata.admin.doctrine_phpcr.phpcr_odm_tree')
+            ->replaceArgument(7, $config['fetch_lazy']);
     }
 
     /**

--- a/Resources/config/tree.xml
+++ b/Resources/config/tree.xml
@@ -24,6 +24,7 @@
             <argument type="service" id="templating.helper.assets" strict="false"/>
             <argument/>
             <argument/>
+            <argument/>
         </service>
 
     </services>


### PR DESCRIPTION
count($this->getDocumentChildren($manager, $document)); is now removed - uncommented the less perfect but still better working other solution
