### PR TITLE
Fix Tree/PhpcrOdmTree.php uninitialized variable

### DIFF
--- a/Tree/PhpcrOdmTree.php
+++ b/Tree/PhpcrOdmTree.php
@@ -380,6 +380,8 @@ class PhpcrOdmTree implements TreeInterface
      */
     public function getNodeTypes()
     {
+        $result = array();
+
         foreach ($this->validClasses as $className => $children) {
             $rel = $this->normalizeClassname($className);
             $admin = $this->getAdminByClass($className);


### PR DESCRIPTION
Hi,

this fix an error occuring when menu admin template is rendering, due to the uninitialized variable $result

Thanks
