### PR TITLE
allow reference many for sonata_type_collection

### DIFF
--- a/Resources/views/Form/form_admin_fields.html.twig
+++ b/Resources/views/Form/form_admin_fields.html.twig
@@ -134,6 +134,7 @@ file that was distributed with this source code.
 
 {% block sonata_type_collection_widget %}
     {% if sonata_admin.field_description.mappingtype == 4
+        or sonata_admin.field_description.mappingtype == 8
         or sonata_admin.field_description.mappingtype == 'children'
         or sonata_admin.field_description.mappingtype == 'referrers'
     %}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | check travis |
| Fixed tickets | n.a. |
| License | MIT |
| Doc PR | n.a. |

or is there a specific reason not to allow refernce many here?
