### PR TITLE
[WIP] Add extra data to DocumentToArray return format for jstree 3 compatibility

### DIFF
--- a/Tree/PhpcrOdmTree.php
+++ b/Tree/PhpcrOdmTree.php
@@ -243,7 +243,11 @@ class PhpcrOdmTree implements TreeInterface
         }
 
         return array(
+            'id' => $id,
+            'text' => $label,
             'data'  => $label,
+            'icon' => '',
+            'type' => $rel,
             'attr'  => array(
                 'id' => $id,
                 'url_safe_id' => $urlSafeId,


### PR DESCRIPTION
Perhaps this doesnt belong here although the OdmTree method being modified is already returning data that is somewhat specific to the jstree plugin. This adds a few extra keys that would be necessary to allow it to serve the right data format for jstree 3
