### PR TITLE
Fix the Admin getSubject() method to work with phpcr node IDs

### DIFF
--- a/Admin/Admin.php
+++ b/Admin/Admin.php
@@ -12,6 +12,7 @@
 namespace Sonata\DoctrinePHPCRAdminBundle\Admin;
 
 use PHPCR\Util\PathHelper;
+use PHPCR\Util\UUIDHelper;
 use Sonata\AdminBundle\Admin\Admin as BaseAdmin;
 use Sonata\AdminBundle\Route\RouteCollection;
 use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
@@ -77,6 +78,31 @@ class Admin extends BaseAdmin
     public function id($object)
     {
         return $this->getUrlsafeIdentifier($object);
+    }
+
+    /**
+     * Get subject
+     *
+     * Overridden to allow a broader set of valid characters in the ID, and
+     * if the ID is not a UUID, to call absolutizePath on the ID.
+     *
+     * @return mixed
+     */
+    public function getSubject()
+    {
+        if ($this->subject === null && $this->request) {
+            $id = $this->request->get($this->getIdParameter());
+            if (!preg_match('#^[0-9A-Za-z/-_]+$#', $id)) {
+                $this->subject = false;
+            } else {
+                if (!UUIDHelper::isUUID($id)) {
+                    $id = PathHelper::absolutizePath($id, '/');
+                }
+                $this->subject = $this->getModelManager()->find($this->getClass(), $id);
+            }
+        }
+
+        return $this->subject;
     }
 
     /**


### PR DESCRIPTION
The base Sonata Admin class has an overly strict regex limiting what can be a valid document ID to numbers and uppercase/lowercase A-F. This PR loosens the characters allowed, and calls absolutizePath on the ID before doing a find with the document manager.
