### PR TITLE
escape dash in Admin getSubject regex

### DIFF
--- a/Admin/Admin.php
+++ b/Admin/Admin.php
@@ -92,7 +92,7 @@ class Admin extends BaseAdmin
     {
         if ($this->subject === null && $this->request) {
             $id = $this->request->get($this->getIdParameter());
-            if (!preg_match('#^[0-9A-Za-z/-_]+$#', $id)) {
+            if (!preg_match('#^[0-9A-Za-z/\-_]+$#', $id)) {
                 $this->subject = false;
             } else {
                 if (!UUIDHelper::isUUID($id)) {


### PR DESCRIPTION
Previously the dash was treated as a range of characters between / and _, which is definitely not the intended behavior.
