### PR TITLE
add bootstrap-3-compatible classes

### DIFF
--- a/Resources/views/CRUD/edit_phpcr_many_to_many.html.twig
+++ b/Resources/views/CRUD/edit_phpcr_many_to_many.html.twig
@@ -20,10 +20,10 @@ file that was distributed with this source code.
                 <a
                     href="{{ sonata_admin.field_description.associationadmin.generateUrl('create') }}"
                     onclick="start_field_dialog_form_add_{{ id }}(event)"
-                    class="btn sonata-ba-action"
+                    class="btn btn-success btn-sm btn-outline sonata-ba-action"
                     title="{{ btn_add|trans({}, btn_catalogue) }}"
                     >
-                    <i class="icon-plus"></i>
+                    <i class="icon-plus fa fa-plus-circle"></i>
                     {{ btn_add|trans({}, btn_catalogue) }}
                 </a>
             {% endif %}

--- a/Resources/views/CRUD/edit_phpcr_many_to_one.html.twig
+++ b/Resources/views/CRUD/edit_phpcr_many_to_one.html.twig
@@ -47,10 +47,10 @@ file that was distributed with this source code.
             {% if sonata_admin.edit == 'list' and sonata_admin.field_description.associationadmin.hasRoute('list') and sonata_admin.field_description.associationadmin.isGranted('LIST') and btn_list %}
                 <a  href="{{ sonata_admin.field_description.associationadmin.generateUrl('list') }}"
                     onclick="start_field_dialog_form_list_{{ id }}(event)"
-                    class="btn sonata-ba-action"
+                    class="btn btn-info btn-sm btn-outline sonata-ba-action"
                     title="{{ btn_list|trans({}, btn_catalogue) }}"
                     >
-                    <i class="icon-plus"></i>
+                    <i class="icon-plus fa fa-list"></i>
                     {{ btn_list|trans({}, btn_catalogue) }}
                 </a>
             {% endif %}
@@ -58,10 +58,10 @@ file that was distributed with this source code.
             {% if sonata_admin.field_description.associationadmin.hasRoute('create') and sonata_admin.field_description.associationadmin.isGranted('CREATE') and btn_add %}
                 <a  href="{{ sonata_admin.field_description.associationadmin.generateUrl('create') }}"
                     onclick="start_field_dialog_form_add_{{ id }}(event)"
-                    class="btn sonata-ba-action"
+                    class="btn btn-success btn-sm btn-outline sonata-ba-action"
                     title="{{ btn_add|trans({}, btn_catalogue) }}"
                     >
-                    <i class="icon-plus"></i>
+                    <i class="icon-plus fa fa-plus-circle"></i>
                     {{ btn_add|trans({}, btn_catalogue) }}
                 </a>
             {% endif %}
@@ -69,10 +69,10 @@ file that was distributed with this source code.
             {% if sonata_admin.field_description.associationadmin.hasRoute('delete') and sonata_admin.field_description.associationadmin.isGranted('DELETE') and btn_delete %}
                 <a  href=""
                     onclick="remove_selected_element_{{ id }}(event)"
-                    class="btn sonata-ba-action"
+                    class="btn btn-danger btn-sm btn-outline sonata-ba-action"
                     title="{{ btn_delete|trans({}, btn_catalogue) }}"
                     >
-                    <i class="icon-off"></i>
+                    <i class="icon-off fa fa-minus-circle"></i>
                     {{ btn_delete|trans({}, btn_catalogue) }}
                 </a>
             {% endif %}

--- a/Resources/views/CRUD/edit_phpcr_one_to_many.html.twig
+++ b/Resources/views/CRUD/edit_phpcr_one_to_many.html.twig
@@ -88,10 +88,10 @@ file that was distributed with this source code.
                     <a
                         href="{{ sonata_admin.field_description.associationadmin.generateUrl('create') }}"
                         onclick="return start_field_retrieve_{{ id }}(this);"
-                        class="btn sonata-ba-action"
+                        class="btn btn-success btn-sm btn-outline sonata-ba-action"
                         title="{{ btn_add|trans({}, btn_catalogue) }}"
                         >
-                        <i class="icon-plus"></i>
+                        <i class="icon-plus fa fa-plus-circle"></i>
                         {{ btn_add|trans({}, btn_catalogue) }}
                     </a>
                 </span>
@@ -141,10 +141,10 @@ file that was distributed with this source code.
                     <a
                         href="{{ sonata_admin.field_description.associationadmin.generateUrl('create') }}"
                         onclick="return start_field_dialog_form_add_{{ id }}(this);"
-                        class="btn sonata-ba-action"
+                        class="btn btn-success btn-sm btn-outline sonata-ba-action"
                         title="{{ btn_add|trans({}, btn_catalogue) }}"
                         >
-                        <i class="icon-plus"></i>
+                        <i class="icon-plus fa fa-plus-circle"></i>
                         {{ btn_add|trans({}, btn_catalogue) }}
                     </a>
                 {% endif %}

--- a/Resources/views/CRUD/edit_phpcr_one_to_one.html.twig
+++ b/Resources/views/CRUD/edit_phpcr_one_to_one.html.twig
@@ -47,10 +47,10 @@ file that was distributed with this source code.
 
                 <a  href="{{ sonata_admin.field_description.associationadmin.generateUrl('list') }}"
                     onclick="start_field_dialog_form_list_{{ id }}(event)"
-                    class="btn sonata-ba-action"
+                    class="btn btn-info btn-sm btn-outline sonata-ba-action"
                     title="{{ btn_list|trans({}, btn_catalogue) }}"
                     >
-                    <i class="icon-list"></i>
+                    <i class="icon-list fa fa-list"></i>
                     {{ btn_list|trans({}, btn_catalogue) }}
                 </a>
             {% endif %}
@@ -58,10 +58,10 @@ file that was distributed with this source code.
             {% if sonata_admin.field_description.associationadmin.hasroute('create') and sonata_admin.field_description.associationadmin.isGranted('CREATE') and btn_add %}
                 <a  href="{{ sonata_admin.field_description.associationadmin.generateUrl('create') }}"
                     onclick="start_field_dialog_form_add_{{ id }}(event)"
-                    class="btn sonata-ba-action"
+                    class="btn btn-success btn-sm btn-outline sonata-ba-action"
                     title="{{ btn_add|trans({}, btn_catalogue) }}"
                     >
-                    <i class="icon-plus"></i>
+                    <i class="icon-plus fa fa-plus-circle"></i>
                     {{ btn_add|trans({}, btn_catalogue) }}
                 </a>
             {% endif %}
@@ -69,10 +69,10 @@ file that was distributed with this source code.
             {% if sonata_admin.field_description.associationadmin.hasRoute('delete') and sonata_admin.field_description.associationadmin.isGranted('DELETE') and btn_delete %}
                 <a  href=""
                     onclick="remove_selected_element_{{ id }}(event)"
-                    class="btn sonata-ba-action"
+                    class="btn btn-danger btn-sm btn-outline sonata-ba-action"
                     title="{{ btn_delete|trans({}, btn_catalogue) }}"
                     >
-                    <i class="icon-off"></i>
+                    <i class="icon-off fa fa-minus-circle"></i>
                     {{ btn_delete|trans({}, btn_catalogue) }}
                 </a>
             {% endif %}

--- a/Resources/views/Form/form_admin_fields.html.twig
+++ b/Resources/views/Form/form_admin_fields.html.twig
@@ -78,10 +78,10 @@ file that was distributed with this source code.
 
                 <a  href="{{ sonata_admin.field_description.associationadmin.generateUrl('list') }}"
                     onclick="return start_field_dialog_form_list_{{ id }}(this);"
-                    class="btn sonata-ba-action"
+                    class="btn btn-info btn-sm btn-outline sonata-ba-action"
                     title="{{ btn_list|trans({}, btn_catalogue) }}"
                     >
-                    <i class="icon-list"></i>
+                    <i class="icon-list fa fa-list"></i>
                     {{ btn_list|trans({}, btn_catalogue) }}
                 </a>
             {% endif %}
@@ -89,10 +89,10 @@ file that was distributed with this source code.
             {% if sonata_admin.field_description.associationadmin.hasroute('create') and sonata_admin.field_description.associationadmin.isGranted('CREATE') and btn_add %}
                 <a  href="{{ sonata_admin.field_description.associationadmin.generateUrl('create') }}"
                     onclick="return start_field_dialog_form_add_{{ id }}(this);"
-                    class="btn sonata-ba-action"
+                    class="btn btn-success btn-sm btn-outline sonata-ba-action"
                     title="{{ btn_add|trans({}, btn_catalogue) }}"
                     >
-                    <i class="icon-plus"></i>
+                    <i class="icon-plus fa fa-plus-circle"></i>
                     {{ btn_add|trans({}, btn_catalogue) }}
                 </a>
             {% endif %}
@@ -100,10 +100,10 @@ file that was distributed with this source code.
             {% if sonata_admin.field_description.associationadmin.hasRoute('delete') and sonata_admin.field_description.associationadmin.isGranted('DELETE') and btn_delete %}
                 <a  href=""
                     onclick="return remove_selected_element_{{ id }}(this);"
-                    class="btn sonata-ba-action"
+                    class="btn btn-danger btn-sm btn-outline sonata-ba-action"
                     title="{{ btn_delete|trans({}, btn_catalogue) }}"
                     >
-                    <i class="icon-off"></i>
+                    <i class="icon-off fa fa-minus-circle"></i>
                     {{ btn_delete|trans({}, btn_catalogue) }}
                 </a>
             {% endif %}


### PR DESCRIPTION
But stay compatible with bootstrap 2. This means adding classes without removing the `icon-plus` class, for instance. But maybe there should be a new release of this bundle that would drop compatibility with bootstrap 2 ?

Fixes #290 
