### PR TITLE
require SonataAdminBundle 2.4 and TreeBrowserBundle 2.0, drop use of SonataJqueryBundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,13 +18,12 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "sonata-project/admin-bundle": ">=2.2.9,<=2.3.0",
-        "sonata-project/jquery-bundle": "1.8.*",
+        "sonata-project/admin-bundle": "~2.4",
         "symfony/framework-bundle": "~2.3",
         "symfony/property-access": "~2.2",
         "doctrine/phpcr-odm": "~1.1",
         "doctrine/phpcr-bundle": "~1.1",
-        "symfony-cmf/tree-browser-bundle": "~1.0"
+        "symfony-cmf/tree-browser-bundle": "~2.0"
     },
     "require-dev": {
         "jackalope/jackalope-jackrabbit": "~1.0"
@@ -37,7 +36,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.2-dev"
+            "dev-master": "2.0-dev"
         }
     }
 }


### PR DESCRIPTION
will require additional work to integrate bower for jquery:
https://github.com/sonata-project/SonataDoctrinePhpcrAdminBundle/issues/323

see also https://github.com/symfony-cmf/TreeBrowserBundle/issues/81