### PR TITLE
Can reorder 1st item to 2nd position with a list greater than 3

### DIFF
--- a/Form/Listener/CollectionOrderListener.php
+++ b/Form/Listener/CollectionOrderListener.php
@@ -71,7 +71,7 @@ class CollectionOrderListener
                 // do not re-add a deleted child
                 continue;
             }
-            if ($item->getName()) {
+            if ($item->getName() && !is_numeric($item->getName())) {
                 // keep key in collection
                 $newCollection[$item->getName()] = $item->getData();
             } else {


### PR DESCRIPTION
This fixes a bug where you have a collection with 3 or more items with no name and you move the 1st item to position two. The moved item gets removed from the list.

[0,1,2]
ordering to [1,0,2] gets inserted in the following manner
[-,1,-]
[-,1,0]
[-,1,2]
The last insert overwrites the second.
