### PR TITLE
add admin extension to split edit and view locale

### DIFF
--- a/Admin/Extension/TranslatableExtension.php
+++ b/Admin/Extension/TranslatableExtension.php
@@ -1,0 +1,101 @@
+<?php
+
+/*
+ * This file is part of the Sonata package.
+ *
+ * (c) 2010-2011 Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace Sonata\DoctrinePHPCRAdminBundle\Admin\Extension;
+
+use Knp\Menu\ItemInterface as MenuItemInterface;
+use Sonata\AdminBundle\Admin\AdminExtension;
+use Sonata\AdminBundle\Admin\AdminInterface;
+use Sonata\AdminBundle\Form\FormMapper;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+class TranslatableExtension extends AdminExtension
+{
+    /**
+     * @var array
+     */
+    protected $availableLocales;
+
+    /**
+     * @var string
+     */
+    protected $defaultLocale;
+
+    /**
+     * @var RequestStack
+     */
+    protected $requestStack;
+
+    /**
+     * @param array $availableLocales
+     * @param string $defaultLocale
+     * @param RequestStack $requestStack
+     */
+    public function __construct(array $availableLocales, $defaultLocale, RequestStack $requestStack)
+    {
+        $this->availableLocales = $availableLocales;
+        $this->defaultLocale = $defaultLocale;
+        $this->requestStack = $requestStack;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configureTabMenu(
+        AdminInterface $admin,
+        MenuItemInterface $menu,
+        $action,
+        AdminInterface $childAdmin = null
+    ) {
+        $label = $admin->trans('choose_edit_locale', [], 'SonataDoctrinePHPCRAdmin');
+        $menuItem = $menu->addChild($label, ['attributes' => ['dropdown' => true]]);
+
+        foreach ($this->availableLocales as $locale) {
+            $urlParameter = ['editLocale' => $locale];
+
+            if (is_object($admin->getSubject())) {
+                $url = $admin->generateObjectUrl($action, $admin->getSubject(), $urlParameter);
+            } else {
+                $url = $admin->generateUrl($action, $urlParameter);
+            }
+
+            $label = $admin->trans($locale, [], 'SonataDoctrinePHPCRAdmin');
+            $menuItem->addChild($label, ['uri' => $url]);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function configureFormFields(FormMapper $formMapper)
+    {
+        $editLocale = $this->getEditLocale();
+
+        $formMapper
+            ->add('editLocale', 'hidden', ['data' => $editLocale, 'mapped' => false])
+            ->end();
+    }
+
+    /**
+     * @return string
+     */
+    protected function getEditLocale()
+    {
+        $locale = $this->defaultLocale;
+        $request = $this->requestStack->getCurrentRequest();
+
+        if ($request instanceof Request) {
+            $locale = $request->get('editLocale', $locale);
+        }
+
+        return $locale;
+    }
+}

--- a/DependencyInjection/SonataDoctrinePHPCRAdminExtension.php
+++ b/DependencyInjection/SonataDoctrinePHPCRAdminExtension.php
@@ -61,6 +61,7 @@ class SonataDoctrinePHPCRAdminExtension extends AbstractSonataAdminExtension
         $loader->load('block.xml');
         $loader->load('tree.xml');
         $loader->load('autocomplete.xml');
+        $loader->load('translatable.xml');
 
         $configuration = new Configuration();
         $processor = new Processor();

--- a/Resources/config/translatable.xml
+++ b/Resources/config/translatable.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <parameters>
+        <parameter key="sonata.admin.admin_extension.translatable.class">Sonata\DoctrinePHPCRAdminBundle\Admin\Extension\TranslatableExtension</parameter>
+    </parameters>
+
+    <services>
+
+        <service id="sonata.admin.admin_extension.translatable" class="%sonata.admin.admin_extension.translatable.class%">
+            <argument>%cmf_core.multilang.locales%</argument>
+            <argument>%cmf_core.sonata_admin.extension.translatable.form_group%</argument>
+            <argument type="service" id="request_stack" />
+            <tag name="sonata.admin.extension"/>
+        </service>
+
+    </services>
+</container>

--- a/Resources/translations/SonataDoctrinePHPCRAdmin.de.xliff
+++ b/Resources/translations/SonataDoctrinePHPCRAdmin.de.xliff
@@ -30,6 +30,10 @@
                 <source>not_editable</source>
                 <target>(nicht editierbar)</target>
             </trans-unit>
+            <trans-unit id="choose_edit_locale">
+                <source>choose_edit_locale</source>
+                <target>Editierungssprache wählen</target>
+            </trans-unit>
         </body>
      </file>
 </xliff>

--- a/Resources/translations/SonataDoctrinePHPCRAdmin.en.xliff
+++ b/Resources/translations/SonataDoctrinePHPCRAdmin.en.xliff
@@ -33,7 +33,11 @@
             <trans-unit id="label_type_contains_words">
                 <source>label_type_contains_words</source>
                 <target>contains words</target>
-            </trans-unit>            
+            </trans-unit>
+            <trans-unit id="choose_edit_locale">
+                <source>choose_edit_locale</source>
+                <target>Choose language to edit</target>
+            </trans-unit>
         </body>
      </file>
 </xliff>


### PR DESCRIPTION
To enable editors to keep their native/desired language for the
adminstration GUI, he/she should have the possibility to set an edit locale
independently of the current admin locale.

What is still missing in this PR is the actual loading/saving in the chosen
edit locale. 

@dbu @ElectricMaxxx This is the stuff I started to work on the Symfony 
CMF hackdays. Unfortunately I didn't really continue afterwards, so its really work in progress.

I hope its at least a small help for you guys :)

To activate it in the cmf-sandbox project:

```yaml
sonata.admin.admin_extension.translatable:
    implements:
        - Symfony\Cmf\Bundle\CoreBundle\Translatable\TranslatableInterface
```