### PR TITLE
Allow all SonataAdminBundle 2.3 versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "sonata-project/admin-bundle": ">=2.2.9,<=2.3.0",
+        "sonata-project/admin-bundle": ">=2.2.9,<2.4.0-dev",
         "sonata-project/jquery-bundle": "1.8.*",
         "symfony/framework-bundle": "~2.3",
         "symfony/property-access": "~2.2",


### PR DESCRIPTION
https://github.com/sonata-project/SonataDoctrinePhpcrAdminBundle/pull/302 did allowed 2.3.0 to be installed, but only 2.3.0. This PR allows 2.3.x to be installed.

This is required for https://github.com/symfony-cmf/cmf-sandbox/pull/288

Can someone please merge this and create a new minor release?

/cc @dbu @lsmith77 