### PR TITLE
[WIP] Improve TreeBrowserBundle experience

### DIFF
--- a/Resources/views/Form/form_admin_fields.html.twig
+++ b/Resources/views/Form/form_admin_fields.html.twig
@@ -158,17 +158,7 @@ file that was distributed with this source code.
                 {% set routing_default_values = routing_default_values|merge({default: app.request.attributes.get(default)}) %}
             {% endif %}
         {% endfor %}
-        var $treeTooltip = $('#{{ id }}-tree-tooltip');
-
-        $treeTooltip.hide(100);
-
-        $('#{{ id }}-tree-tooltip-open').click(function (e) {
-            e.preventDefault();
-
-            $treeTooltip.toggle();
-        });
-
-        $('#{{ id }}-tree-selector').cmfTree({
+        var tree = $('#{{ id }}-tree-selector').cmfTree({
             request: {
                 load: function (nodePath) {
                     return {
@@ -183,40 +173,52 @@ file that was distributed with this source code.
         });
 
         $('#{{ id }}-tree-selector-output').cmfAutoComplete({
-            'data': function (path) {
-                var nodes = [];
-                var root = path.substr(0, path.lastIndexOf('/'));
+            data: function (nodePath, next) {
+                if (tree.getFromCache(nodePath)) {
+                    next(tree.getFromCache(nodePath));
+
+                    return;
+                }
 
                 jQuery.ajax({
-                    url: Routing.generate('_cmf_tree_{{ tree.alias }}_children', defaults),
+                    url: '{{ path('_cmf_resource', {
+                        repositoryName: repository_name,
+                        path: '__path__'
+                    }|merge(routing_default_values)) }}'.replace('__path__', nodePath.replace(/^\//, '')),
                     dataType: 'json',
                     type: 'GET',
-                    data: {root: root},
                     success: function (data) {
-                        data.forEach(function (node) {
-                            nodes.push(node.attr.id.substr(node.attr.id.lastIndexOf('/') + 1));
-                        });
+                        var nodes = [];
 
-                        return nodes;
+                        for (name in data.children) {
+                            if (data.children.hasOwnProperty(name)) {
+                                nodes.push(name);
+                            }
+                        }
+
+                        next(nodes);
                     }
                 });
-
-                return nodes;
             }
+        });
+
+        var $input = $('#{{ id }}-tree-selector-output');
+        $('#{{ id }}-tree-reset').click(function () {
+            $input.val('{{ value ?: (select_root_node ? root_node : '') }}');
         });
     });
 </script>
 
-<div class="form-inline">
+<div class="form-inline dropdown">
     <input class="form-control" name="{{ full_name }}" id="{{ id }}-tree-selector-output" list="{{ id }}-tree-datalist" value="{{ value ?: (select_root_node ? root_node : '') }}">
     <datalist id="{{ id }}-tree-datalist"></datalist>
 
-    <button class="btn btn-mini" id="{{ id }}-tree-tooltip-open">Select</button>
-    <button class="btn btn-mini" id={{ id }}-tree-reset>{{ 'reset_tree' | trans({}, 'SonataDoctrinePHPCRAdmin') }}</button>
-</div>
+    <span class="btn btn-default btn-mini" data-toggle="dropdown">Select</span>
+    <span class="btn btn-default btn-mini" id={{ id }}-tree-reset>{{ 'reset_tree' | trans({}, 'SonataDoctrinePHPCRAdmin') }}</span>
 
-<div id="{{ id }}-tree-tooltip">
-    <div id="{{ id }}-tree-selector"></div>
+    <div id="{{ id }}-tree-tooltip" class="dropdown-menu">
+        <div id="{{ id }}-tree-selector"></div>
+    </div>
 </div>
 {% endblock %}
 

--- a/Resources/views/Form/form_admin_fields.html.twig
+++ b/Resources/views/Form/form_admin_fields.html.twig
@@ -206,6 +206,10 @@ file that was distributed with this source code.
         $('#{{ id }}-tree-reset').click(function () {
             $input.val('{{ value ?: (select_root_node ? root_node : '') }}');
         });
+
+        $('#{{ id }}-tree-tooltip').click(function (e) {
+            e.stopPropagation();
+        });
     });
 </script>
 

--- a/Resources/views/Form/form_admin_fields.html.twig
+++ b/Resources/views/Form/form_admin_fields.html.twig
@@ -158,6 +158,15 @@ file that was distributed with this source code.
                 {% set routing_default_values = routing_default_values|merge({default: app.request.attributes.get(default)}) %}
             {% endif %}
         {% endfor %}
+        var $treeTooltip = $('#{{ id }}-tree-tooltip');
+
+        $treeTooltip.hide(100);
+
+        $('#{{ id }}-tree-tooltip-open').click(function (e) {
+            e.preventDefault();
+
+            $treeTooltip.toggle();
+        });
 
         $('#{{ id }}-tree-selector').cmfTree({
             request: {
@@ -172,15 +181,42 @@ file that was distributed with this source code.
             },
             path_output: '#{{ id }}-tree-selector-output'
         });
+
+        $('#{{ id }}-tree-selector-output').cmfAutoComplete({
+            'data': function (path) {
+                var nodes = [];
+                var root = path.substr(0, path.lastIndexOf('/'));
+
+                jQuery.ajax({
+                    url: Routing.generate('_cmf_tree_{{ tree.alias }}_children', defaults),
+                    dataType: 'json',
+                    type: 'GET',
+                    data: {root: root},
+                    success: function (data) {
+                        data.forEach(function (node) {
+                            nodes.push(node.attr.id.substr(node.attr.id.lastIndexOf('/') + 1));
+                        });
+
+                        return nodes;
+                    }
+                });
+
+                return nodes;
+            }
+        });
     });
 </script>
 
-<div id="{{id}}-tree-selector"></div>
-
 <div class="form-inline">
-    <input class="form-control" name="{{ full_name }}" id="{{ id }}-tree-selector-output" value="{{ value ?: (select_root_node ? root_node : '') }}">
+    <input class="form-control" name="{{ full_name }}" id="{{ id }}-tree-selector-output" list="{{ id }}-tree-datalist" value="{{ value ?: (select_root_node ? root_node : '') }}">
+    <datalist id="{{ id }}-tree-datalist"></datalist>
 
-    <button class="btn btn-mini" id={{id}}-tree-reset>{{ 'reset_tree' | trans({}, 'SonataDoctrinePHPCRAdmin') }}</button>
+    <button class="btn btn-mini" id="{{ id }}-tree-tooltip-open">Select</button>
+    <button class="btn btn-mini" id={{ id }}-tree-reset>{{ 'reset_tree' | trans({}, 'SonataDoctrinePHPCRAdmin') }}</button>
+</div>
+
+<div id="{{ id }}-tree-tooltip">
+    <div id="{{ id }}-tree-selector"></div>
 </div>
 {% endblock %}
 


### PR DESCRIPTION
This is probably one of the last big PRs regarding the TreeBrowserbundle 2.0. It changes the way the tree is used to something that's familair to all computer users.

When opening the form, the tree view is hidden and only the input box is shown:
![cmf-tree-minimal](https://cloud.githubusercontent.com/assets/749025/7556128/f9fd31f8-f764-11e4-847a-6fc2b5fc2937.png)

When the admin want to select a node, they can do 2 things:

* Type into the input field. The TreeBrowserBundle provides auto completion for the admin:
  ![cmf-tree-autocompletion](https://cloud.githubusercontent.com/assets/749025/7556134/3166ba10-f765-11e4-8208-57fb8397e21e.png)
* Click the "select" button. This opens a tooltip with the tree:
   ![cmf-tree-tooltip](https://cloud.githubusercontent.com/assets/749025/7556137/425f77da-f765-11e4-864c-38063934802b.png)

Both the tree view and the input field are keep in sync: Changing the input value changes the selected node in the tree and selecting a node in the tree changes the input value.

I'm not sure yet if it's very obvious what to do here for the admin, but I believe it is a step in the good direction as it'll hide those very long trees on a page.

This PR doesn't change admin for the manager (or admin) trees.

Fixes https://github.com/symfony-cmf/TreeBrowserBundle/issues/76