### PR TITLE
Fix definition of Twig filters

### DIFF
--- a/Twig/Extension/SonataDoctrinePHPCRAdminExtension.php
+++ b/Twig/Extension/SonataDoctrinePHPCRAdminExtension.php
@@ -21,8 +21,8 @@ class SonataDoctrinePHPCRAdminExtension extends \Twig_Extension
     public function getFilters()
     {
         return array(
-            'render_node_property' => new \Twig_SimpleFilter(array($this, 'renderNodeProperty'), array('is_safe' => array('html'))),
-            'render_node_path'     => new \Twig_SimpleFilter(array($this, 'renderNodePath'), array('is_safe' => array('html'))),
+            new \Twig_SimpleFilter('render_node_property', array($this, 'renderNodeProperty'), array('is_safe' => array('html'))),
+            new \Twig_SimpleFilter('render_node_path', array($this, 'renderNodePath'), array('is_safe' => array('html'))),
         );
     }
 


### PR DESCRIPTION
```
An exception has been thrown during the compilation of a template
("Warning: Illegal offset type") in "layout.html.twig". 
```

```php
        foreach ($extension->getFilters() as $name => $filter) {
            if ($filter instanceof Twig_SimpleFilter) {
                $name = $filter->getName(); // $name is an array()!!
            }
            ...

            $this->filters[$name] = $filter;
        }
```