### PR TITLE
symfony-cmf/tree-browser-bundle v 2.0 doesn't exist

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "symfony/property-access": "~2.2",
         "doctrine/phpcr-odm": "~1.1",
         "doctrine/phpcr-bundle": "~1.1",
-        "symfony-cmf/tree-browser-bundle": "~2.0",
+        "symfony-cmf/tree-browser-bundle": "~1.0",
         "symfony-cmf/resource-rest-bundle": "~1.0"
     },
     "require-dev": {


### PR DESCRIPTION
According to 

https://github.com/symfony-cmf/TreeBrowserBundle