### PR TITLE
require the ACL package only in dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,6 @@
         "php": ">=5.5",
         "sonata-project/admin-bundle": "~2.4",
         "sonata-project/block-bundle": "^2.3.2",
-        "symfony/security-acl": "~2.4",
         "symfony/framework-bundle": "~2.3",
         "symfony/property-access": "~2.2",
         "doctrine/phpcr-odm": "~1.1",
@@ -30,6 +29,7 @@
     "require-dev": {
         "jackalope/jackalope-jackrabbit": "~1.0",
         "symfony/phpunit-bridge": "~2.7|~3.0",
+        "symfony/security-acl": "~2.4",
         "fabpot/php-cs-fixer": "~0.1|~1.0"
     },
     "provide": {


### PR DESCRIPTION
It is not mentioned at all in the code, but the admin bundle, which is a
dependency of this package, mentions it in its code, which can make the
tests fail.