### PR TITLE
Fix wrong class name

### DIFF
--- a/Builder/FormContractor.php
+++ b/Builder/FormContractor.php
@@ -141,7 +141,7 @@ class FormContractor implements FormContractorInterface
                 $fieldDescription->setOption('edit', $fieldDescription->getOption('edit', 'admin'));
 
                 break;
-            case 'Sonata\AdminBundle\Form\Type\CollectionType':
+            case 'Sonata\CoreBundle\Form\Type\CollectionType':
             case 'sonata_type_collection':
                 if (!$fieldDescription->getAssociationAdmin()) {
                     throw $this->getAssociationAdminException($fieldDescription);


### PR DESCRIPTION
This bug is breaking every save/create action in the CMF sandbox admin panel (see also https://github.com/symfony-cmf/cmf-sandbox/issues/316) at the moment. @lsmith77 @dbu can you please merge + tag a new 1.2 release quickly?