### PR TITLE
Support for nested mappings

### DIFF
--- a/Resources/views/Form/form_admin_fields.html.twig
+++ b/Resources/views/Form/form_admin_fields.html.twig
@@ -233,6 +233,9 @@ file that was distributed with this source code.
                 var controlGroupIdFunc = function (field) {
                     return '#sonata-ba-field-container-{{ main_form_name }}' + field;
                 };
+                var controlInputIdFunc = function (field) {
+                    return '#{{ main_form_name }}' + field;
+                };
 
                 if (map[val] == undefined) {
                     $.each(allFields, function (i, field) {
@@ -244,6 +247,7 @@ file that was distributed with this source code.
 
                 $.each(allFields, function (i, field) {
                     if (map[val].indexOf(field) == -1) {
+                        $(controlInputIdFunc(field)).data('required', $(controlInputIdFunc(field)).prop('required')).prop('required', false);
                         var $fieldContainer = $(controlGroupIdFunc(field));
                         if ($fieldContainer.filter(':visible').length) {
                             $fieldContainer.trigger('hideMappedChildren').hide();
@@ -252,6 +256,7 @@ file that was distributed with this source code.
                 });
 
                 $.each(map[val], function (i, field) {
+                    $(controlInputIdFunc(field)).prop('required', $(controlInputIdFunc(field)).data('required'));
                     var $fieldContainer = $(controlGroupIdFunc(field));
                     if ($fieldContainer.filter(':hidden').length) {
                         $fieldContainer.trigger('showMappedChildren').show();

--- a/Resources/views/Form/form_admin_fields.html.twig
+++ b/Resources/views/Form/form_admin_fields.html.twig
@@ -205,6 +205,25 @@ file that was distributed with this source code.
             var map = {{ map|json_encode|raw }};
 
             showMaskChoiceEl = $('#{{ main_form_name }}{{ name }}');
+
+            showMaskChoiceEl.data('mappedFields', allFields);
+            $.each(allFields, function (i, field) {
+                $('#sonata-ba-field-container-{{ main_form_name }}' + field).on('hideMappedChildren', function () {
+                    var mappedFields = $('#{{ main_form_name }}' + field).data('mappedFields');
+                    if (mappedFields) {
+                        $.each(mappedFields, function (i, mappedFieldName) {
+                            $('#sonata-ba-field-container-{{ main_form_name }}' + mappedFieldName).filter(':visible')
+                                    .hide().trigger('hideMappedChildren');
+                        });
+                    }
+                }).on('showMappedChildren', function () {
+                    var mappedFields = $('#{{ main_form_name }}' + field).data('mappedFields');
+                    if (mappedFields) {
+                        $('#{{ main_form_name }}' + field).trigger('change');
+                    }
+                });
+            });
+
             showMaskChoiceEl.on('change', function () {
                 choice_field_mask_show($(this).val());
             });
@@ -224,11 +243,19 @@ file that was distributed with this source code.
                 }
 
                 $.each(allFields, function (i, field) {
-                    $(controlGroupIdFunc(field)).hide();
+                    if (map[val].indexOf(field) == -1) {
+                        var $fieldContainer = $(controlGroupIdFunc(field));
+                        if ($fieldContainer.filter(':visible').length) {
+                            $fieldContainer.trigger('hideMappedChildren').hide();
+                        }
+                    }
                 });
 
                 $.each(map[val], function (i, field) {
-                    $(controlGroupIdFunc(field)).show();
+                    var $fieldContainer = $(controlGroupIdFunc(field));
+                    if ($fieldContainer.filter(':hidden').length) {
+                        $fieldContainer.trigger('showMappedChildren').show();
+                    }
                 });
             }
 


### PR DESCRIPTION
This change adds support for nested mappings.

Example:

``` php
$formMapper
    ->add('car_model', 'choice_field_mask', [
        'choices' => [
            'nice_car' => 'Mercedes',
            'bad_car'  => 'Opel',
        ],
        'map' => [
            'nice_car' => ['nice_car_color'],
            'bad_car' => ['bad_car_color']
        ]
    ])
    ->add('nice_car_color', 'choice_field_mask', [
        'choices' => [
            'silver' => 'silver',
            'black'  => 'black',
        ],
        'map' => [
            'silver' => ['exclusive_color'],
            'black' => [],
        ]
    ])
    ->add('exclusive_color', 'choice', [
        'choices' => [
            'silver1' => 'premium silver',
            'silver2' => 'ultra premium silver',
        ]
    ])
    ->add('bad_car_color', 'choice', [
        'choices' => [
            'blue' => 'blue',
            'red'  => 'red',
        ]
    ])
;
```

`exclusive_color` will only be visible if you select Mercedes AND silver.
`exclusive_color` will be hidden if you change `nice_car_color` (default behaviour) and now also if you change its parent `car_model`.
