### PR TITLE
Fix even more Symfony 3 support (and some other bugs)

### DIFF
--- a/DependencyInjection/SonataDoctrinePHPCRAdminExtension.php
+++ b/DependencyInjection/SonataDoctrinePHPCRAdminExtension.php
@@ -90,12 +90,6 @@ class SonataDoctrinePHPCRAdminExtension extends AbstractSonataAdminExtension
 
         $options = $config['document_tree_options'];
         $container->setParameter('sonata_admin_doctrine_phpcr.tree_confirm_move', $options['confirm_move']);
-
-        unset($options['confirm_move']);
-
-        $container->getDefinition('sonata.admin.doctrine_phpcr.phpcr_odm_tree')
-            ->replaceArgument(5, $this->processDocumentTreeConfig($config['document_tree']))
-            ->replaceArgument(6, $options);
     }
 
     /**

--- a/Filter/CallbackFilter.php
+++ b/Filter/CallbackFilter.php
@@ -13,6 +13,7 @@ namespace Sonata\DoctrinePHPCRAdminBundle\Filter;
 
 use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
 use Sonata\DoctrinePHPCRAdminBundle\Filter\Filter as BaseFilter;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 
 class CallbackFilter extends BaseFilter
 {
@@ -38,7 +39,7 @@ class CallbackFilter extends BaseFilter
     {
         return array(
             'callback'         => null,
-            'field_type'       => 'text',
+            'field_type'       => TextType::class,
             'operator_type'    => 'hidden',
             'operator_options' => array(),
         );

--- a/Filter/NodeNameFilter.php
+++ b/Filter/NodeNameFilter.php
@@ -62,7 +62,7 @@ class NodeNameFilter extends Filter
      */
     public function getRenderSettings()
     {
-        return array('doctrine_phpcr_type_filter_choice', array(
+        return array(ChoiceType::class, array(
             'field_type'    => $this->getFieldType(),
             'field_options' => $this->getFieldOptions(),
             'label'         => $this->getLabel(),

--- a/Filter/StringFilter.php
+++ b/Filter/StringFilter.php
@@ -68,7 +68,7 @@ class StringFilter extends Filter
      */
     public function getRenderSettings()
     {
-        return array('doctrine_phpcr_type_filter_choice', array(
+        return array(ChoiceType::class, array(
             'field_type'    => $this->getFieldType(),
             'field_options' => $this->getFieldOptions(),
             'label'         => $this->getLabel(),

--- a/Guesser/FilterTypeGuesser.php
+++ b/Guesser/FilterTypeGuesser.php
@@ -11,15 +11,15 @@
 
 namespace Sonata\DoctrinePHPCRAdminBundle\Guesser;
 
+use Doctrine\Bundle\PHPCRBundle\Form\Type\DocumentType;
 use Doctrine\Bundle\PHPCRBundle\ManagerRegistry;
 use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
 use Doctrine\ODM\PHPCR\Mapping\MappingException;
-use Doctrine\Bundle\PHPCRBundle\Form\Type\DocumentType;
 use Sonata\AdminBundle\Guesser\TypeGuesserInterface;
 use Sonata\AdminBundle\Model\ModelManagerInterface;
 use Sonata\CoreBundle\Form\Type\BooleanType;
-use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\Extension\Core\Type\NumberType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\Guess\Guess;
 use Symfony\Component\Form\Guess\TypeGuess;
 

--- a/Guesser/FilterTypeGuesser.php
+++ b/Guesser/FilterTypeGuesser.php
@@ -14,8 +14,12 @@ namespace Sonata\DoctrinePHPCRAdminBundle\Guesser;
 use Doctrine\Bundle\PHPCRBundle\ManagerRegistry;
 use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
 use Doctrine\ODM\PHPCR\Mapping\MappingException;
+use Doctrine\Bundle\PHPCRBundle\Form\Type\DocumentType;
 use Sonata\AdminBundle\Guesser\TypeGuesserInterface;
 use Sonata\AdminBundle\Model\ModelManagerInterface;
+use Sonata\CoreBundle\Form\Type\BooleanType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\Extension\Core\Type\NumberType;
 use Symfony\Component\Form\Guess\Guess;
 use Symfony\Component\Form\Guess\TypeGuess;
 
@@ -50,9 +54,9 @@ class FilterTypeGuesser implements TypeGuesserInterface
         }
 
         $options = array(
-            'field_type'     => 'text',
-            'field_options'  => array(),
-            'options'        => array(),
+            'field_type'    => TextType::class,
+            'field_options' => array(),
+            'options'       => array(),
         );
 
         if ($metadata->hasAssociation($property)) {
@@ -62,7 +66,7 @@ class FilterTypeGuesser implements TypeGuesserInterface
             $options['operator_type'] = 'sonata_type_boolean';
             $options['operator_options'] = array();
 
-            $options['field_type'] = 'document';
+            $options['field_type'] = DocumentType::class;
             if (!empty($mapping['targetDocument'])) {
                 $options['field_options'] = array(
                     'class' => $mapping['targetDocument'],
@@ -85,7 +89,7 @@ class FilterTypeGuesser implements TypeGuesserInterface
         $options['field_name'] = $property;
         switch ($metadata->getTypeOfField($property)) {
             case 'boolean':
-                $options['field_type'] = 'sonata_type_boolean';
+                $options['field_type'] = BooleanType::class;
                 $options['field_options'] = array();
 
                 return new TypeGuess('doctrine_phpcr_boolean', $options, Guess::HIGH_CONFIDENCE);
@@ -95,7 +99,7 @@ class FilterTypeGuesser implements TypeGuesserInterface
             case 'float':
                 return new TypeGuess('doctrine_phpcr_number', $options, Guess::HIGH_CONFIDENCE);
             case 'integer':
-                $options['field_type'] = 'number';
+                $options['field_type'] = NumberType::class;
                 $options['field_options'] = array(
                     'csrf_protection' => false,
                 );
@@ -103,7 +107,7 @@ class FilterTypeGuesser implements TypeGuesserInterface
                 return new TypeGuess('doctrine_phpcr_integer', $options, Guess::HIGH_CONFIDENCE);
             case 'text':
             case 'string':
-                $options['field_type'] = 'text';
+                $options['field_type'] = TextType::class;
 
                 return new TypeGuess('doctrine_phpcr_string', $options, Guess::HIGH_CONFIDENCE);
         }

--- a/Guesser/TypeGuesser.php
+++ b/Guesser/TypeGuesser.php
@@ -16,9 +16,9 @@ use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
 use Doctrine\ODM\PHPCR\Mapping\MappingException;
 use Sonata\AdminBundle\Guesser\TypeGuesserInterface;
 use Sonata\AdminBundle\Model\ModelManagerInterface;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\Guess\Guess;
 use Symfony\Component\Form\Guess\TypeGuess;
-use Symfony\Component\Form\Extension\Core\Type\TextType;
 
 /**
  * Guesser for displaying fields.

--- a/Guesser/TypeGuesser.php
+++ b/Guesser/TypeGuesser.php
@@ -18,6 +18,7 @@ use Sonata\AdminBundle\Guesser\TypeGuesserInterface;
 use Sonata\AdminBundle\Model\ModelManagerInterface;
 use Symfony\Component\Form\Guess\Guess;
 use Symfony\Component\Form\Guess\TypeGuess;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 
 /**
  * Guesser for displaying fields.
@@ -51,7 +52,7 @@ class TypeGuesser implements TypeGuesserInterface
     public function guessType($class, $property, ModelManagerInterface $modelManager)
     {
         if (!$metadata = $this->getMetadata($class)) {
-            return new TypeGuess('text', array(), Guess::LOW_CONFIDENCE);
+            return new TypeGuess(TextType::class, array(), Guess::LOW_CONFIDENCE);
         }
 
         if ($metadata->hasAssociation($property)) {
@@ -94,7 +95,7 @@ class TypeGuesser implements TypeGuesserInterface
                 return new TypeGuess('string', array(), Guess::MEDIUM_CONFIDENCE);
         }
 
-        return new TypeGuess('text', array(), Guess::LOW_CONFIDENCE);
+        return new TypeGuess(TextType::class, array(), Guess::LOW_CONFIDENCE);
     }
 
     /**

--- a/Resources/config/tree.xml
+++ b/Resources/config/tree.xml
@@ -16,17 +16,6 @@
             <call method="setContainer"><argument type="service" id="service_container"/></call>
         </service>
 
-        <service id="sonata.admin.doctrine_phpcr.phpcr_odm_tree" class="Sonata\DoctrinePHPCRAdminBundle\Tree\PhpcrOdmTree">
-            <argument type="service" id="doctrine_phpcr.odm.default_document_manager" />
-            <argument type="service" id="sonata.admin.manager.doctrine_phpcr"/>
-            <argument type="service" id="sonata.admin.pool"/>
-            <argument type="service" id="translator"/>
-            <argument type="service" id="templating.helper.assets" strict="false"/>
-            <argument/>
-            <argument/>
-            <argument/>
-        </service>
-
     </services>
 
 </container>

--- a/Resources/views/Form/form_admin_fields.html.twig
+++ b/Resources/views/Form/form_admin_fields.html.twig
@@ -57,11 +57,11 @@ file that was distributed with this source code.
     <div id="field_container_{{ id }}" class="field-container">
         <span id="field_widget_{{ id }}" >
             {% if sonata_admin.field_description.associationadmin.id(sonata_admin.value) %}
-                {% render url('sonata_admin_short_object_information', {
+                {{ render(url('sonata_admin_short_object_information', {
                     'code':     sonata_admin.field_description.associationadmin.code,
                     'objectId': sonata_admin.field_description.associationadmin.id(sonata_admin.value),
                     'uniqid':   sonata_admin.field_description.associationadmin.uniqid
-                }) %}
+                })) }}
             {% elseif sonata_admin.field_description.options.placeholder is defined and sonata_admin.field_description.options.placeholder %}
                 <span class="inner-field-short-description">
                     {{ sonata_admin.field_description.options.placeholder|trans({}, 'SonataAdminBundle') }}

--- a/SonataDoctrinePHPCRAdminBundle.php
+++ b/SonataDoctrinePHPCRAdminBundle.php
@@ -11,6 +11,7 @@
 
 namespace Sonata\DoctrinePHPCRAdminBundle;
 
+use Sonata\CoreBundle\Form\FormHelper;
 use Sonata\DoctrinePHPCRAdminBundle\DependencyInjection\Compiler\AddGuesserCompilerPass;
 use Sonata\DoctrinePHPCRAdminBundle\DependencyInjection\Compiler\AddTemplatesCompilerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -23,7 +24,27 @@ class SonataDoctrinePHPCRAdminBundle extends Bundle
      */
     public function build(ContainerBuilder $container)
     {
+        $this->registerFormMapping();
+
         $container->addCompilerPass(new AddGuesserCompilerPass());
         $container->addCompilerPass(new AddTemplatesCompilerPass());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function boot()
+    {
+        $this->registerFormMapping();
+    }
+
+    private function registerFormMapping()
+    {
+        FormHelper::registerFormTypeMapping(array(
+            'doctrine_phpcr_type_filter_choice' => 'Sonata\DoctrinePHPCRAdminBundle\Form\Type\Filter\ChoiceType',
+            'choice_field_mask' => 'Sonata\DoctrinePHPCRAdminBundle\Form\Type\ChoiceFieldMaskType',
+            'doctrine_phpcr_odm_tree_manager' => 'Sonata\DoctrinePHPCRAdminBundle\Form\Type\TreeManagerType',
+            'doctrine_phpcr_odm_tree' => 'Sonata\DoctrinePHPCRAdminBundle\Form\Type\TreeModelType',
+        ));
     }
 }

--- a/SonataDoctrinePHPCRAdminBundle.php
+++ b/SonataDoctrinePHPCRAdminBundle.php
@@ -42,9 +42,9 @@ class SonataDoctrinePHPCRAdminBundle extends Bundle
     {
         FormHelper::registerFormTypeMapping(array(
             'doctrine_phpcr_type_filter_choice' => 'Sonata\DoctrinePHPCRAdminBundle\Form\Type\Filter\ChoiceType',
-            'choice_field_mask' => 'Sonata\DoctrinePHPCRAdminBundle\Form\Type\ChoiceFieldMaskType',
-            'doctrine_phpcr_odm_tree_manager' => 'Sonata\DoctrinePHPCRAdminBundle\Form\Type\TreeManagerType',
-            'doctrine_phpcr_odm_tree' => 'Sonata\DoctrinePHPCRAdminBundle\Form\Type\TreeModelType',
+            'choice_field_mask'                 => 'Sonata\DoctrinePHPCRAdminBundle\Form\Type\ChoiceFieldMaskType',
+            'doctrine_phpcr_odm_tree_manager'   => 'Sonata\DoctrinePHPCRAdminBundle\Form\Type\TreeManagerType',
+            'doctrine_phpcr_odm_tree'           => 'Sonata\DoctrinePHPCRAdminBundle\Form\Type\TreeModelType',
         ));
     }
 }

--- a/Tests/Guesser/FilterTypeGuesserTest.php
+++ b/Tests/Guesser/FilterTypeGuesserTest.php
@@ -3,6 +3,7 @@
 namespace Sonata\DoctrinePHPCRAdminBundle\Tests\Guesser;
 
 use Sonata\DoctrinePHPCRAdminBundle\Guesser\FilterTypeGuesser;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\Guess\Guess;
 
 class FilterTypeGuesserTest extends \PHPUnit_Framework_TestCase
@@ -48,7 +49,7 @@ class FilterTypeGuesserTest extends \PHPUnit_Framework_TestCase
         );
         $this->assertSame(
             array(
-                'field_type'      => 'text',
+                'field_type'      => TextType::class,
                 'field_options'   => array(),
                 'options'         => array(),
                 'field_name'      => $fieldname,


### PR DESCRIPTION
Tests still have to be updated. This was the minimum required things to get at least something working. My guess is that this bundle needs a lot more fixes before working 100% on Symfony 3.

Can we bump to PHP 5.5 support, or do I still need to put the FQCN in strings instead of using `::class`?