### PR TITLE
Require SonataBlockBundle 3.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "~5.5|~7.0",
         "sonata-project/admin-bundle": "~3.0",
-        "sonata-project/block-bundle": "^2.3.2",
+        "sonata-project/block-bundle": "~3.0",
         "symfony/framework-bundle": "~2.3|~3.0",
         "symfony/property-access": "~2.2|~3.0",
         "doctrine/phpcr-odm": "~1.1",


### PR DESCRIPTION
SonataAdminBundle 3.x requires SonataBlockBundle 3.x.