### PR TITLE
[WIP] Update bundle for move ResourceRestBundle changes

### DIFF
--- a/Resources/views/Form/form_admin_fields.html.twig
+++ b/Resources/views/Form/form_admin_fields.html.twig
@@ -163,7 +163,7 @@ file that was distributed with this source code.
             request: {
                 load: function (nodePath) {
                     return {
-                        url: '{{ path('_cmf_resource', {
+                        url: '{{ path('_get_cmf_resource', {
                             repositoryName: repository_name,
                             path: '__path__'
                         }|merge(routing_default_values)) }}'.replace('__path__', nodePath)

--- a/Resources/views/Tree/tree.html.twig
+++ b/Resources/views/Tree/tree.html.twig
@@ -24,6 +24,7 @@ file that was distributed with this source code.
 <script type="text/javascript">
     jQuery(function($) {
         $('#tree').cmfTree({
+            dnd: { enabled: true },
             request: {
                 load: function (nodePath) {
                     return {
@@ -33,6 +34,13 @@ file that was distributed with this source code.
                             path: '__path__'
                         }|merge(routing_default_values)) }}'.replace('__path__', nodePath)
                     };
+                },
+                move: function (nodePath) {
+                    return '{{ path('_patch_cmf_resource', {
+                        repositoryName: repository_name,
+                        root_node: root_node,
+                        path: '__path__'
+                    }|merge(routing_default_values)) }}'.replace('__path__', nodePath)
                 }
             },
             actions: {

--- a/Resources/views/Tree/tree.html.twig
+++ b/Resources/views/Tree/tree.html.twig
@@ -27,7 +27,7 @@ file that was distributed with this source code.
             request: {
                 load: function (nodePath) {
                     return {
-                        url: '{{ path('_cmf_resource', {
+                        url: '{{ path('_get_cmf_resource', {
                             repositoryName: repository_name,
                             root_node: root_node,
                             path: '__path__'


### PR DESCRIPTION
Implements drag 'n drop support in this bundle. It also fixes the renamed route names. 

To be merged once https://github.com/symfony-cmf/resource-rest-bundle/pull/31 is merged

Depends on
---

 * [ ] https://github.com/symfony-cmf/tree-browser-bundle/pull/99
 * [x] https://github.com/symfony-cmf/resource-rest-bundle/pull/36