### PR TITLE
Fixed typo in class name

### DIFF
--- a/Resources/config/autocomplete.xml
+++ b/Resources/config/autocomplete.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
-        <service id="sonata.admin.doctrine_phpcr.autocomplete_controller" class="Sonata\DoctrinePHPCRAdminBundle\Controller\AutoCompleteController">
+        <service id="sonata.admin.doctrine_phpcr.autocomplete_controller" class="Sonata\DoctrinePHPCRAdminBundle\Controller\AutocompleteController">
             <argument type="service" id="sonata.admin.pool"/>
         </service>
     </services>


### PR DESCRIPTION
```markdown
### Fixed
- typo in class name
```

