### PR TITLE
removes Admin class deprecation notice

### DIFF
--- a/Admin/Admin.php
+++ b/Admin/Admin.php
@@ -13,7 +13,7 @@ namespace Sonata\DoctrinePHPCRAdminBundle\Admin;
 
 use PHPCR\Util\PathHelper;
 use PHPCR\Util\UUIDHelper;
-use Sonata\AdminBundle\Admin\Admin as BaseAdmin;
+use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
 use Sonata\AdminBundle\Route\RouteCollection;
 
@@ -24,7 +24,7 @@ use Sonata\AdminBundle\Route\RouteCollection;
  *
  * @author Uwe Jäger <uwej711@googlemail.com>
  */
-class Admin extends BaseAdmin
+class Admin extends AbstractAdmin
 {
     /**
      * Path to the root node in the repository under which documents of this

--- a/Tests/Admin/AdminTest.php
+++ b/Tests/Admin/AdminTest.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrinePHPCRAdminBundle\Tests\Admin;
+
+use Sonata\DoctrinePHPCRAdminBundle\Admin\Admin;
+
+class AdminTest extends \PHPUnit_Framework_TestCase
+{
+    public function testItCanBeInstanciated()
+    {
+        $admin = new Admin('', '', '');
+    }
+}

--- a/Tests/Builder/ListBuilderTest.php
+++ b/Tests/Builder/ListBuilderTest.php
@@ -102,7 +102,7 @@ class ListBuilderTest extends \PHPUnit_Framework_TestCase
 
         //AdminInterface doesn't implement methods called in addField,
         //so we mock Admin
-        $this->admin = $this->getMock('\Sonata\AdminBundle\Admin\Admin', array(), array(), '', false);
+        $this->admin = $this->getMock('\Sonata\AdminBundle\Admin\AbstractAdmin', array(), array(), '', false);
         $this->admin->expects($this->any())
             ->method('getModelManager')
             ->will($this->returnValue($this->modelManager));

--- a/Tests/Route/PathInfoBuilderSlashesTest.php
+++ b/Tests/Route/PathInfoBuilderSlashesTest.php
@@ -19,12 +19,16 @@ class PathInfoBuilderSlashesTest extends \PHPUnit_Framework_TestCase
     {
         $collectionChild = $this->getMock('Sonata\\AdminBundle\\Route\\RouteCollection', array(), array(), '', false);
 
-        $adminChild = $this->getMockBuilder('Sonata\\AdminBundle\\Admin\\Admin')->disableOriginalConstructor()->getMock();
+        $adminChild = $this->getMockBuilder('Sonata\\AdminBundle\\Admin\\AbstractAdmin')
+            ->disableOriginalConstructor()
+            ->getMock();
         $adminChild->expects($this->once())
             ->method('getRoutes')
             ->will($this->returnValue($collectionChild));
 
-        $admin = $this->getMockBuilder('Sonata\\AdminBundle\\Admin\\Admin')->disableOriginalConstructor()->getMock();
+        $admin = $this->getMockBuilder('Sonata\\AdminBundle\\Admin\\AbstractAdmin')
+            ->disableOriginalConstructor()
+            ->getMock();
         $admin->expects($this->once())
             ->method('getChildren')
             ->will($this->returnValue(array($adminChild)));
@@ -43,7 +47,9 @@ class PathInfoBuilderSlashesTest extends \PHPUnit_Framework_TestCase
 
     public function testBuildWithAcl()
     {
-        $admin = $this->getMockBuilder('Sonata\\AdminBundle\\Admin\\Admin')->disableOriginalConstructor()->getMock();
+        $admin = $this->getMockBuilder('Sonata\\AdminBundle\\Admin\\AbstractAdmin')
+            ->disableOriginalConstructor()
+            ->getMock();
         $admin->expects($this->once())
             ->method('getChildren')
             ->will($this->returnValue(array()));

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "php": "^5.5 || ^7.0",
         "doctrine/phpcr-bundle": "^1.1",
         "doctrine/phpcr-odm": "^1.1",
-        "sonata-project/admin-bundle": "^3.0",
+        "sonata-project/admin-bundle": "^3.1",
         "sonata-project/block-bundle": "^3.0",
         "symfony-cmf/resource-rest-bundle": "^1.0@dev",
         "symfony-cmf/tree-browser-bundle": "^2.0@dev",


### PR DESCRIPTION
I am targetting this branch, because:
1. I'm not sure if this is BC or not.
2. I'm working on a BC breaking PR in the master branch and I need it to be compatible with the admin bundle's master for that.

If this is wrong, feel free to tell me, I'll rebase the PR on 1.x :wink: 

## Changelog

```markdown
### Fixed
- Deprecated `Sonata\AdminBundle\Admin\Admin` class usage
```

## Subject

The `Sonata\AdminBundle\Admin\Admin` class has been deprecated in favour of `Sonata\AdminBundle\Admin\AbstractAdmin`.
This PR changes the Admin base class to AbstractAdmin