### PR TITLE
Support Doctrine PHPCR-ODM 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^5.5 || ^7.0",
         "doctrine/phpcr-bundle": "^1.1",
-        "doctrine/phpcr-odm": "^1.1",
+        "doctrine/phpcr-odm": "^1.1 || ^2.0",
         "sonata-project/admin-bundle": "^3.1",
         "sonata-project/block-bundle": "^3.0",
         "symfony-cmf/resource-rest-bundle": "^1.0@dev",


### PR DESCRIPTION
Doctrine PHPCR-ODM 2.0-dev has started, which will be required for the Symfony CMF 2.0-dev.

At the moment, no breaking changes affect the features in this bundle, so both 1.x and 2.x can be supported now.