### PR TITLE
Allows phpunit to use project's autoload

### DIFF
--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -9,9 +9,13 @@
  * file that was distributed with this source code.
  */
 
-$file = __DIR__.'/../vendor/autoload.php';
-if (!file_exists($file)) {
+$autoload_paths = array_filter(array(
+    __DIR__.'/../vendor/autoload.php',
+    __DIR__.'/../../../../vendor/autoload.php',
+), 'file_exists');
+
+if (!$autoload_paths) {
     throw new RuntimeException('Run "composer install" to run test suite.');
 }
 
-require_once $file;
+require_once current($autoload_paths);


### PR DESCRIPTION
I am targetting this branch, because it's a BC change

## Changelog

```markdown
### Changed
- PHPUnit bootstrap file now tries to fallback to the autoload.php in the project's vendor directory.
```

