### PR TITLE
Sync with route renamings in CmfResourceRestBundle

### DIFF
--- a/Resources/views/Form/form_admin_fields.html.twig
+++ b/Resources/views/Form/form_admin_fields.html.twig
@@ -163,7 +163,7 @@ file that was distributed with this source code.
             request: {
                 load: function (nodePath) {
                     return {
-                        url: '{{ path('_cmf_resource', {
+                        url: '{{ path('_cmf_get_resource', {
                             repositoryName: repository_name,
                             path: '__path__'
                         }|merge(routing_default_values)) }}'.replace('__path__', nodePath)

--- a/Resources/views/Tree/tree.html.twig
+++ b/Resources/views/Tree/tree.html.twig
@@ -27,7 +27,7 @@ file that was distributed with this source code.
             request: {
                 load: function (nodePath) {
                     return {
-                        url: '{{ path('_cmf_resource', {
+                        url: '{{ path('_cmf_get_resource', {
                             repositoryName: repository_name,
                             root_node: root_node,
                             path: '__path__'


### PR DESCRIPTION
Update the route names to use the new names, otherwise you'll get an error "undefined route `_cmf_resource`".