### PR TITLE
Stop testing with outdated phpunit-bridge version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "sonata-project/core-bundle": "@dev",
         "symfony-cmf/resource": "@dev",
         "symfony-cmf/resource-bundle": "@dev",
-        "symfony/phpunit-bridge": "^2.7 || ^3.0",
+        "symfony/phpunit-bridge": "^2.8 || ^3.0",
         "symfony/security-acl": "^2.8 || ^3.0"
     },
     "provide": {


### PR DESCRIPTION
Refs https://github.com/sonata-project/dev-kit/issues/216
This should have been done when dropping support for Symfony < 2.8

<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 1.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrinePhpcrAdminBundle/blob/1.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch even though this isn't major, because it makes little sense in the stable branch.