### PR TITLE
Get tree working again with the recent Resource updates

### DIFF
--- a/Resources/views/Tree/tree.html.twig
+++ b/Resources/views/Tree/tree.html.twig
@@ -37,12 +37,12 @@ file that was distributed with this source code.
             },
             actions: {
                 'edit': {
-                    url: { data: '?sonata_links.edit' },
+                    url: { data: '?link.edit.html' },
                     label: "{{ 'create_item'|trans({}, 'SonataDoctrinePhpcrAdminBundle') }}",
                     icon: 'fa fa-pencil'
                 },
                 'delete': {
-                    url: { data: '?sonata_links.delete' },
+                    url: { data: '?link.remove.html' },
                     label: "{{ 'delete_item'|trans({}, 'SonataDoctrinePhpcrAdminBundle') }}",
                     icon: 'fa fa-trash-o'
                 }


### PR DESCRIPTION
## Changelog

```markdown
### Changed

- Changed data URLs to be in sync with new format returned by the CmfResourceRestbundle
```

## Subject

The RC version of ResourceRestBundle has a slightly modified return format. That causes the actions to stop working. This PR fixes that by adding support for the new format.

*This should be a no-brainer, please merge quickly so we can continue releasing RC and stable versions of the CMF*