### PR TITLE
add deprecation to remove SimplePager

### DIFF
--- a/Datagrid/SimplePager.php
+++ b/Datagrid/SimplePager.php
@@ -13,6 +13,11 @@ namespace Sonata\DoctrinePHPCRAdminBundle\Datagrid;
 
 use Doctrine\Common\Collections\ArrayCollection;
 
+/**
+ *  NEXT_MAJOR: remove this class.
+
+ * @deprecated since 1.2.7, to be removed in 2.0. Use Sonata\AdminBundle\Datagrid\SimplePager instead.
+ */
 class SimplePager extends Pager
 {
     /**
@@ -46,6 +51,11 @@ class SimplePager extends Pager
      */
     public function __construct($maxPerPage = 10, $threshold = 2)
     {
+        @trigger_error(
+            'The '.__CLASS__.' class is deprecated since 1.2.7, to be removed in 2.0. '.
+            'Use Sonata\AdminBundle\Datagrid\SimplePager instead.',
+            E_USER_DEPRECATED
+        );
         parent::__construct($maxPerPage);
         $this->setThreshold($threshold);
     }

--- a/Tests/Datagrid/SimplePagerBasicTest.php
+++ b/Tests/Datagrid/SimplePagerBasicTest.php
@@ -14,6 +14,9 @@ namespace Sonata\DoctrinePHPCRAdminBundle\Tests\Datagrid;
 use Doctrine\Common\Collections\ArrayCollection;
 use Sonata\DoctrinePHPCRAdminBundle\Datagrid\SimplePager;
 
+/**
+ * @group legacy
+ */
 class SimplePagerBasicTest extends \PHPUnit_Framework_TestCase
 {
     public function setUp()

--- a/Tests/Datagrid/SimplePagerTest.php
+++ b/Tests/Datagrid/SimplePagerTest.php
@@ -14,6 +14,9 @@ namespace Sonata\DoctrinePHPCRAdminBundle\Tests\Datagrid;
 use Doctrine\Common\Collections\ArrayCollection;
 use Sonata\DoctrinePHPCRAdminBundle\Datagrid\SimplePager;
 
+/**
+ * @group legacy
+ */
 class SimplePagerTest extends \PHPUnit_Framework_TestCase
 {
     public function setUp()

--- a/UPGRADE-1.x.md
+++ b/UPGRADE-1.x.md
@@ -1,6 +1,10 @@
 UPGRADE 1.x
 ===========
 
+### Deprecated `Sonata\DoctrinePHPCRAdminBundle\Datagrid\SimplePager`
+
+When adding pager function you should use `Sonata\AdminBundle\Datagrid\SimplePager` now.
+
 ### Tests
 
 All files under the ``Tests`` directory are now correctly handled as internal test classes. 


### PR DESCRIPTION
```markdown
### Deprecated
- `SimplePager`, in favor of Sonata's simple pager.
```

just adds the deprecation warning on a stable branch.