### PR TITLE
Filter lower case

### DIFF
--- a/Resources/doc/reference/filter_field_definition.rst
+++ b/Resources/doc/reference/filter_field_definition.rst
@@ -179,3 +179,32 @@ implement this functionality.
             return true;
         }
     }
+
+Filtering Fields and Case Sensitivity
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The default behaviour when filtering is to compare values in a case sensitive manner.
+For example "Test" is not the same as "test". Depending on your use case, you might want case insensitive filtering.
+To make the filter case insensitive, use the ``compare_case_insensitive`` option for the string filter:
+
+.. code-block:: php
+
+    <?php
+    namespace My\AppBundle\Admin;
+
+    use Sonata\AdminBundle\Admin\Admin;
+    use Sonata\AdminBundle\Datagrid\DatagridMapper;
+
+    use Application\Sonata\NewsBundle\Document\Comment;
+
+    class PostAdmin extends Admin
+    {
+        protected function configureDatagridFilters(DatagridMapper $datagridMapper)
+        {
+            $datagridMapper
+                ->add('title', 'doctrine_phpcr_string', array('compare_case_insensitive' => true))
+                ->add('author', 'doctrine_phpcr_string', array('compare_case_insensitive' => true))
+                ->add('label', 'doctrine_phpcr_string')
+            ;
+        }
+    }

--- a/Tests/Filter/StringFilterTest.php
+++ b/Tests/Filter/StringFilterTest.php
@@ -16,6 +16,11 @@ use Sonata\DoctrinePHPCRAdminBundle\Form\Type\Filter\ChoiceType;
 
 class StringFilterTest extends BaseTestCase
 {
+    /**
+     * @var StringFilter
+     */
+    private $filter;
+
     public function setUp()
     {
         parent::setUp();
@@ -83,14 +88,35 @@ class StringFilterTest extends BaseTestCase
                     'getField' => 'somefield',
                     'getFullTextSearchExpression' => 'somevalue', ),
             )),
+            'equalCaseInsensitiveComparision' => array(ChoiceType::TYPE_EQUAL, array(
+                'where.constraint.operand_dynamic.operand_dynamic' => array(
+                    'getAlias' => 'a',
+                    'getField' => 'somefield',
+                ),
+                'where.constraint.operand_static' => array(
+                    'getValue' => 'somevalue',
+                ),
+            ), true),
+            'containsCaseInsensitiveComparision' => array(ChoiceType::TYPE_CONTAINS, array(
+                'where.constraint.operand_dynamic.operand_dynamic' => array(
+                    'getAlias' => 'a',
+                    'getField' => 'somefield',
+                ),
+                'where.constraint.operand_static' => array(
+                    'getValue' => '%somevalue%',
+                ),
+            ), true)
         );
     }
 
     /**
      * @dataProvider getFilters
      */
-    public function testFilterSwitch($choiceType, $assertPaths)
+    public function testFilterSwitch($choiceType, $assertPaths, $isLowerCase = false)
     {
+        if ($isLowerCase) {
+            $this->filter->setOption('compare_case_insensitive', true);
+        }
         $this->filter->filter(
             $this->proxyQuery,
             null,


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 1.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrinePhpcrAdminBundle/blob/1.x/CONTRIBUTING.md#the-base-branch
-->
I am targetting this branch, because *it is for the new release*

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #161 

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- added `compare_lower_case` Option to `Sonata\DoctrinePHPCRAdminBundle\Filter\StringFilter` to enable lower case comparision
```

## To do

* [x] Update the tests
* [x] Update the documentation (add notice/hint)

## Subject

As described in the issue, we what to enable lowercase comparison on string filter.
