### PR TITLE
Fixed inline editing by removing assets from the form type

### DIFF
--- a/DependencyInjection/Compiler/AddTreeBrowserAssetsPass.php
+++ b/DependencyInjection/Compiler/AddTreeBrowserAssetsPass.php
@@ -21,7 +21,7 @@ use Symfony\Component\DependencyInjection\Reference;
  *
  * @author Wouter de Jong <wouter@wouterj.nl>
  */
-class AddTreeBrowserAssetsPass implements CompilerPassInterface
+final class AddTreeBrowserAssetsPass implements CompilerPassInterface
 {
     /**
      * {@inheritdoc}
@@ -32,9 +32,7 @@ class AddTreeBrowserAssetsPass implements CompilerPassInterface
             return;
         }
 
-        $definition = $container->findDefinition('sonata.admin.pool');
-        $this->addAssetsToAdminPool($definition);
-
+        $this->addAssetsToAdminPool($container->findDefinition('sonata.admin.pool'));
         $this->addFormResources($container);
     }
 

--- a/DependencyInjection/Compiler/AddTreeBrowserAssetsPass.php
+++ b/DependencyInjection/Compiler/AddTreeBrowserAssetsPass.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\DoctrinePHPCRAdminBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * Adds javascripts and stylesheets required for the TreeSelectType.
+ *
+ * @author Wouter de Jong <wouter@wouterj.nl>
+ */
+class AddTreeBrowserAssetsPass implements CompilerPassInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasDefinition('sonata.admin.pool')) {
+            return;
+        }
+
+        $definition = $container->findDefinition('sonata.admin.pool');
+        $this->addAssetsToAdminPool($definition);
+
+        $this->addFormResources($container);
+    }
+
+    private function addAssetsToAdminPool(Definition $definition)
+    {
+        $options = $definition->getArgument(3);
+        $options['javascripts'][] = 'bundles/cmftreebrowser/js/cmf_tree_browser.fancytree.js';
+        $options['stylesheets'][] = 'bundles/cmftreebrowser/css/cmf_tree_browser.fancytree.css';
+
+        $definition->replaceArgument(3, $options);
+    }
+
+    private function addFormResources(ContainerBuilder $container)
+    {
+        $resources = $container->getParameter('twig.form.resources');
+        $resources[] = 'SonataDoctrinePHPCRAdminBundle:Form:tree_browser_fields.html.twig';
+
+        $container->setParameter('twig.form.resources', $resources);
+    }
+}

--- a/Resources/views/Form/tree_browser_fields.html.twig
+++ b/Resources/views/Form/tree_browser_fields.html.twig
@@ -1,0 +1,16 @@
+{#
+
+This file is part of the Sonata package.
+
+(c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+
+#}
+
+{% extends '@CmfTreeBrowser/Form/fields.html.twig' %}
+
+{% block cmf_tree_select_widget_assets %}
+    {# avoid assets being loaded for each type, they are loaded by the admin pool #}
+{% endblock %}

--- a/Resources/views/Form/tree_browser_fields.html.twig
+++ b/Resources/views/Form/tree_browser_fields.html.twig
@@ -14,3 +14,27 @@ file that was distributed with this source code.
 {% block cmf_tree_select_widget_assets %}
     {# avoid assets being loaded for each type, they are loaded by the admin pool #}
 {% endblock %}
+
+{% block cmf_tree_select_widget_css %}
+    {# avoid custom styles, AdminLTE is used #}
+{% endblock %}
+
+{% block cmf_tree_select_widget_tooltip %}
+    <div id="{{ id }}-cmf-tree-tooltip" class="dropdown-menu">
+        <div id="{{ id }}-cmf-tree"></div>
+    </div>
+{% endblock %}
+
+{% block cmf_tree_select_widget_input %}
+    <div class="input-group">
+        {{ block('form_widget_simple') }}
+
+        {% if "compact" == widget %}
+            <div class="input-group-btn">
+                <button class="btn btn-primary" id="{{ id }}-cmf-tree-tooltip-toggle">
+                    {{ 'form.button.pick'|trans({}, 'CmfTreeBrowserBundle') }}
+                </button>
+            </div>
+        {% endif %}
+    </div>
+{% endblock %}

--- a/SonataDoctrinePHPCRAdminBundle.php
+++ b/SonataDoctrinePHPCRAdminBundle.php
@@ -14,6 +14,7 @@ namespace Sonata\DoctrinePHPCRAdminBundle;
 use Sonata\CoreBundle\Form\FormHelper;
 use Sonata\DoctrinePHPCRAdminBundle\DependencyInjection\Compiler\AddGuesserCompilerPass;
 use Sonata\DoctrinePHPCRAdminBundle\DependencyInjection\Compiler\AddTemplatesCompilerPass;
+use Sonata\DoctrinePHPCRAdminBundle\DependencyInjection\Compiler\AddTreeBrowserAssetsPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -28,6 +29,7 @@ class SonataDoctrinePHPCRAdminBundle extends Bundle
 
         $container->addCompilerPass(new AddGuesserCompilerPass());
         $container->addCompilerPass(new AddTemplatesCompilerPass());
+        $container->addCompilerPass(new AddTreeBrowserAssetsPass());
     }
 
     /**


### PR DESCRIPTION
Closes #327

## Changelog

```markdown
### Added
- Added `AddTreeBrowserAssetsPass` to load TreeBrowser assets using the admin pool
- Added a custom form theme for the TreeSelectType in order to use AdminLTE
```

## Subject

When adding support for inline editing, an AJAX request is done to load the form. Since the TreeSelectType includes `<script>` tags, calling `.replaceWith(html)` will result in a blank page. Also, as you can read in #327, loading fancytree for each usage of the form type isn't needed. Loading it only once in the head would be much better.

This PR fixes both issues by configuring the admin pool to include the fancytree assets. It also overrides the TreeSelectType to avoid loading these assets again.

Meanwhile, I also added some AdminLTE styles to the TreeSelectType to make styling more consistent and nicer. 

| **Before** | **After**
| --- | ---
| ![cmf-tree-style-before](https://cloud.githubusercontent.com/assets/749025/22861803/18d6598e-f122-11e6-8b13-464243cc0e69.png) | ![cmf-tree-style-after](https://cloud.githubusercontent.com/assets/749025/22861802/18d28066-f122-11e6-9405-890b8f541dd4.png)

