### PR TITLE
Remove service defintion

### DIFF
--- a/Resources/config/doctrine_phpcr_filter_types.xml
+++ b/Resources/config/doctrine_phpcr_filter_types.xml
@@ -14,9 +14,6 @@
             <tag name="form.type" alias="doctrine_phpcr_type_filter_choice"/>
             <argument type="service" id="translator"/>
         </service>
-        <service id="sonata.admin.doctrine_phpcr.filter.type.model" class="Sonata\DoctrinePHPCRAdminBundle\Filter\ModelFilter">
-            <tag name="sonata.admin.filter.type" alias="doctrine_phpcr_model"/>
-        </service>
         <service id="sonata.admin.doctrine_phpcr.filter.type.string" class="Sonata\DoctrinePHPCRAdminBundle\Filter\StringFilter">
             <tag name="sonata.admin.filter.type" alias="doctrine_phpcr_string"/>
         </service>


### PR DESCRIPTION

I am targetting this branch, because it should be fixed on 1.x as that type was never used i guess.

Closes #425 

## Changelog

```markdown
### Removed

A never used service defintion for a filter type.
```

## Subject

In my work i realized by the help of my IDE that there is a Service with a not existing class.