### PR TITLE
Build actions field description based on provided type too

### DIFF
--- a/Builder/ListBuilder.php
+++ b/Builder/ListBuilder.php
@@ -81,7 +81,7 @@ class ListBuilder implements ListBuilderInterface
      */
     public function fixFieldDescription(AdminInterface $admin, FieldDescriptionInterface $fieldDescription)
     {
-        if ($fieldDescription->getName() == '_action') {
+        if ($fieldDescription->getName() == '_action' || $fieldDescription->getType() === 'actions') {
             $this->buildActionFieldDescription($fieldDescription);
         }
 
@@ -172,7 +172,7 @@ class ListBuilder implements ListBuilderInterface
         }
 
         if (null === $fieldDescription->getType()) {
-            $fieldDescription->setType('action');
+            $fieldDescription->setType('actions');
         }
 
         if (null === $fieldDescription->getOption('name')) {

--- a/Tests/Builder/ListBuilderTest.php
+++ b/Tests/Builder/ListBuilderTest.php
@@ -12,7 +12,6 @@
 namespace Sonata\DoctrinePHPCRAdminBundle\Tests\Builder;
 
 use Sonata\DoctrinePHPCRAdminBundle\Builder\ListBuilder;
-use Prophecy\Argument;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Guesser\TypeGuesserInterface;
 use Sonata\DoctrinePHPCRAdminBundle\Admin\FieldDescription;
@@ -176,4 +175,3 @@ class ListBuilderTest extends \PHPUnit_Framework_TestCase
         );
     }
 }
-


### PR DESCRIPTION
I am targeting this branch, because it's a patch.

References sonata-project/SonataDoctrineORMAdminBundle#672.

## Changelog

```markdown
### Fixed
- A list field with `actions` type will get all the required field options just like the `_action` field.
- `_action` field will get a proper `actions` type.
```
## Subject

`ListBuilder` fix, mirrors SonataDoctrineORMAdmin change.