### PR TITLE
Move and reorder and sorable tree

### DIFF
--- a/Controller/TreeController.php
+++ b/Controller/TreeController.php
@@ -14,6 +14,7 @@ namespace Sonata\DoctrinePHPCRAdminBundle\Controller;
 use Doctrine\Bundle\PHPCRBundle\ManagerRegistry;
 use PHPCR\Util\PathHelper;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -111,12 +112,16 @@ class TreeController extends Controller
      */
     public function reorderAction(Request $request)
     {
-        $parent = $request->request->get('parent');
-        $moved = $request->request->get('dropped');
-        $target = $request->request->get('target');
-        $position = $request->request->get('position');
-        $before = 'before' == $position;
+        $parent = $request->get('parent');
+        $moved = $request->get('dropped');
+        $target = $request->get('target');
+        $position = $request->get('position');
 
+        if (null === $parent || null === $moved || null === $target) {
+            return new JsonResponse(['Parameters parent, dropped and target has to be set to reorder.'], Response::HTTP_BAD_REQUEST);
+        }
+
+        $before = 'before' == $position;
         $parentNode = $this->session->getNode($parent);
         $targetName = PathHelper::getNodeName($target);
         if (!$before) {

--- a/Controller/TreeController.php
+++ b/Controller/TreeController.php
@@ -112,18 +112,18 @@ class TreeController extends Controller
      */
     public function reorderAction(Request $request)
     {
-        $parent = $request->get('parent');
-        $moved = $request->get('dropped');
-        $target = $request->get('target');
+        $parentPath = $request->get('parent');
+        $dropedAtPath = $request->get('dropped');
+        $targetPath = $request->get('target');
         $position = $request->get('position');
 
-        if (null === $parent || null === $moved || null === $target) {
+        if (null === $parentPath || null === $dropedAtPath || null === $targetPath) {
             return new JsonResponse(['Parameters parent, dropped and target has to be set to reorder.'], Response::HTTP_BAD_REQUEST);
         }
 
         $before = 'before' == $position;
-        $parentNode = $this->session->getNode($parent);
-        $targetName = PathHelper::getNodeName($target);
+        $parentNode = $this->session->getNode($parentPath);
+        $targetName = PathHelper::getNodeName($targetPath);
         if (!$before) {
             $nodesIterator = $parentNode->getNodes();
             $nodesIterator->rewind();
@@ -141,7 +141,7 @@ class TreeController extends Controller
                 }
             }
         }
-        $parentNode->orderBefore(PathHelper::getNodeName($moved), $targetName);
+        $parentNode->orderBefore($targetName, PathHelper::getNodeName($dropedAtPath));
         $this->session->save();
 
         return new Response('', Response::HTTP_NO_CONTENT);

--- a/Description/PositionEnhancer.php
+++ b/Description/PositionEnhancer.php
@@ -22,6 +22,10 @@ class PositionEnhancer implements DescriptionEnhancerInterface
      */
     private $session;
 
+    /**
+     * @param ManagerRegistry $manager
+     * @param $sessionName
+     */
     public function __construct(ManagerRegistry $manager, $sessionName)
     {
         $this->session = $manager->getConnection($sessionName);

--- a/Description/PositionEnhancer.php
+++ b/Description/PositionEnhancer.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Sonata\DoctrinePHPCRAdminBundle\Description;
+
+use Doctrine\Common\Persistence\ManagerRegistry;
+use PHPCR\PathNotFoundException;
+use Symfony\Cmf\Component\Resource\Description\Description;
+use Symfony\Cmf\Component\Resource\Description\DescriptionEnhancerInterface;
+use Symfony\Cmf\Component\Resource\Puli\Api\PuliResource;
+
+/**
+ * A description enhancer to add the position/sorting value of children on a parent.
+ *
+ * @author Maximilian Berghoff <Maximilian.Berghoff@mayflower.de>
+ */
+class PositionEnhancer implements DescriptionEnhancerInterface
+{
+    /**
+     * @var \PHPCR\SessionInterface
+     */
+    private $session;
+
+    public function __construct(ManagerRegistry $manager, $sessionName)
+    {
+        $this->session = $manager->getConnection($sessionName);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function enhance(Description $description)
+    {
+        try {
+            $node = $this->session->getNode($description->getResource()->getPath());
+        } catch (PathNotFoundException $exception) {
+            return;
+        }
+
+        $description->set('position', $node->getIndex());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supports(PuliResource $resource)
+    {
+        return true;
+    }
+}

--- a/Description/PositionEnhancer.php
+++ b/Description/PositionEnhancer.php
@@ -46,7 +46,7 @@ class PositionEnhancer implements DescriptionEnhancerInterface
         $nodeIterator = $parentNode->getNodes();
         $nodeIterator->rewind();
         $counter = 0;
-        while($nodeIterator->valid()) {
+        while ($nodeIterator->valid()) {
             $counter++;
             if ($nodeIterator->key() === $nodeName) {
                 break;

--- a/Form/Extension/CollectionTypeExtension.php
+++ b/Form/Extension/CollectionTypeExtension.php
@@ -15,6 +15,8 @@ use Sonata\DoctrinePHPCRAdminBundle\Form\Listener\CollectionOrderListener;
 use Symfony\Component\Form\AbstractTypeExtension;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormEvents;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormView;
 
 /**
  * Extend the sonata collection type to sort the collection so the reordering

--- a/Resources/config/doctrine_phpcr.xml
+++ b/Resources/config/doctrine_phpcr.xml
@@ -49,7 +49,7 @@
         <service id="sonata.admin.description.position_enhancer" class="Sonata\DoctrinePHPCRAdminBundle\Description\PositionEnhancer">
             <argument type="service" id="doctrine_phpcr"/>
             <argument>%doctrine_phpcr.default_session%</argument>
-            <tag name="cmf_resource.description.enhancer" alias="doctrine_phpcr_position" />
+            <tag name="cmf_resource.description.enhancer" alias="doctrine_phpcr_position"/>
         </service>
     </services>
 </container>

--- a/Resources/config/doctrine_phpcr.xml
+++ b/Resources/config/doctrine_phpcr.xml
@@ -48,7 +48,7 @@
         </service>
         <service id="sonata.admin.description.position_enhancer" class="Sonata\DoctrinePHPCRAdminBundle\Description\PositionEnhancer">
             <argument type="service" id="doctrine_phpcr"/>
-            <argument>%doctrine_phpcr.default_session%%</argument>
+            <argument>%doctrine_phpcr.default_session%</argument>
             <tag name="cmf_resource.description.enhancer" alias="doctrine_phpcr_position" />
         </service>
     </services>

--- a/Resources/config/doctrine_phpcr.xml
+++ b/Resources/config/doctrine_phpcr.xml
@@ -46,5 +46,10 @@
         <service id="sonata.admin.guesser.doctrine_phpcr_datagrid_chain" class="Sonata\AdminBundle\Guesser\TypeGuesserChain">
             <argument/>
         </service>
+        <service id="sonata.admin.description.position_enhancer" class="Sonata\DoctrinePHPCRAdminBundle\Description\PositionEnhancer">
+            <argument type="service" id="doctrine_phpcr"/>
+            <argument>%doctrine_phpcr.default_session%%</argument>
+            <tag name="cmf_resource.description.enhancer" alias="doctrine_phpcr_position" />
+        </service>
     </services>
 </container>

--- a/Resources/config/routing/tree.xml
+++ b/Resources/config/routing/tree.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <routes xmlns="http://symfony.com/schema/routing" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
     <route id="sonata_admin_tree" path="/tree">
-        <default key="_controller">SonataDoctrinePHPCRAdminBundle:Tree:index</default>
+        <default key="_controller">SonataDoctrinePHPCRAdminBundle:Tree:tree</default>
+    </route>
+    <route id="sonata_admin_tree_reorder" path="/tree/reorder">
+        <default key="_controller">SonataDoctrinePHPCRAdminBundle:Tree:reorder</default>
     </route>
 </routes>

--- a/Resources/config/routing/tree.xml
+++ b/Resources/config/routing/tree.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <routes xmlns="http://symfony.com/schema/routing" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
     <route id="sonata_admin_tree" path="/tree">
-        <default key="_controller">SonataDoctrinePHPCRAdminBundle:Tree:tree</default>
+        <default key="_controller">sonata.admin.doctrine_phpcr.tree_controller:treeAction</default>
     </route>
     <route id="sonata_admin_tree_reorder" path="/tree/reorder">
-        <default key="_controller">SonataDoctrinePHPCRAdminBundle:Tree:reorder</default>
+        <default key="_controller">sonata.admin.doctrine_phpcr.tree_controller:reorderAction</default>
     </route>
 </routes>

--- a/Resources/config/tree.xml
+++ b/Resources/config/tree.xml
@@ -2,6 +2,8 @@
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
         <service id="sonata.admin.doctrine_phpcr.tree_controller" class="Sonata\DoctrinePHPCRAdminBundle\Controller\TreeController">
+            <argument type="service" id="doctrine_phpcr" />
+            <argument>%doctrine_phpcr.default_session%</argument>
             <argument>%sonata_admin_doctrine_phpcr.tree_block.repository_name%</argument>
             <argument/>
             <argument>%sonata_admin_doctrine_phpcr.tree_block.defaults%</argument>

--- a/Resources/config/tree.xml
+++ b/Resources/config/tree.xml
@@ -2,7 +2,7 @@
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
         <service id="sonata.admin.doctrine_phpcr.tree_controller" class="Sonata\DoctrinePHPCRAdminBundle\Controller\TreeController">
-            <argument type="service" id="doctrine_phpcr" />
+            <argument type="service" id="doctrine_phpcr"/>
             <argument>%doctrine_phpcr.default_session%</argument>
             <argument>%sonata_admin_doctrine_phpcr.tree_block.repository_name%</argument>
             <argument/>

--- a/Resources/views/Tree/tree.html.twig
+++ b/Resources/views/Tree/tree.html.twig
@@ -54,6 +54,27 @@ file that was distributed with this source code.
                     ).then(function (firstResponse, secondResponse) {
                         return secondResponse.shift();
                     });
+                },
+                reorder: function (parentPath, movedPath, targetPath, position) {
+                    return $.when(
+                        $.ajax(
+                              '{{ path('sonata_admin_tree_reorder') }}',
+                              {
+                                  data: JSON.stringify([{
+                                    "parent": parentPath,
+                                    "dropped": movedPath,
+                                    "target": targetPath,
+                                    "position": position
+                                  }]),
+                                  method: 'POST',
+                                  dataType: 'json',
+                                  contentType: 'application/json; charset=utf-8'
+                              }
+                        ),
+                        $.ajax(apiGetTemplate.replace('__path__', movedPath), {dataType: 'json'})
+                    ).then(function (firstResponse, secondResponse) {
+                        return secondResponse.shift();
+                    });
                 }
             },
             actions: {
@@ -68,7 +89,7 @@ file that was distributed with this source code.
                     icon: 'fa fa-trash-o'
                 }
             },
-            dnd: {enabled: true}
+            dnd: {enabled: true, reorder: true}
         });
     });
 </script>

--- a/Resources/views/Tree/tree.html.twig
+++ b/Resources/views/Tree/tree.html.twig
@@ -22,7 +22,7 @@ file that was distributed with this source code.
 
 {% include 'CmfTreeBrowserBundle:Base:tree.html.twig' %}
 <script type="text/javascript">
-    var apiUrlTemplate = '{{ path('_cmf_get_resource', {
+    var apiGetTemplate = '{{ path('_cmf_get_resource', {
         repositoryName: repository_name,
         root_node: root_node,
         path: '__path__'
@@ -32,13 +32,17 @@ file that was distributed with this source code.
             request: {
                 load: function (nodePath) {
                     return {
-                        url: apiUrlTemplate.replace('__path__', nodePath)
+                        url: apiGetTemplate.replace('__path__', nodePath)
                     };
                 },
                 move: function (sourcePath, destinationPath) {
                     return $.when(
                         $.ajax(
-                            apiUrlTemplate.replace('__path__', sourcePath),
+                            '{{ path('_cmf_patch_resource', {
+                                repositoryName: repository_name,
+                                root_node: root_node,
+                                path: '__path__'
+                            }|merge(routing_default_values)) }}'.replace('__path__', sourcePath),
                             {
                                 data: JSON.stringify([{"operation": "move", "target": destinationPath}]),
                                 method: 'PATCH',
@@ -46,10 +50,10 @@ file that was distributed with this source code.
                                 contentType: 'application/json; charset=utf-8'
                             }
                         ),
-                        $.ajax(apiUrlTemplate.replace('__path__', destinationPath), {dataType: 'json'})
-                        ).then(function (firstResponse, secondResponse) {
-                            return secondResponse.shift();
-                        });
+                        $.ajax(apiGetTemplate.replace('__path__', destinationPath), {dataType: 'json'})
+                    ).then(function (firstResponse, secondResponse) {
+                        return secondResponse.shift();
+                    });
                 }
             },
             actions: {

--- a/Resources/views/Tree/tree.html.twig
+++ b/Resources/views/Tree/tree.html.twig
@@ -36,11 +36,13 @@ file that was distributed with this source code.
                     };
                 },
                 move: function (sourcePath, destinationPath) {
-                    var body = [{"operation": "move", "target": destinationPath}];
-
                     return $.ajax(
                       apiUrlTemplate.replace('__path__', sourcePath),
-                      {data: body, method: 'PATCH', dataType: 'json', contentType: 'application/json'}
+                      {
+                        data: JSON.stringify([{"operation": "move", "target": destinationPath}]),
+                        method: 'PATCH',
+                        dataType: 'json',
+                        contentType: 'application/json; charset=utf-8'}
                     );
                 }
             },

--- a/Resources/views/Tree/tree.html.twig
+++ b/Resources/views/Tree/tree.html.twig
@@ -22,17 +22,26 @@ file that was distributed with this source code.
 
 {% include 'CmfTreeBrowserBundle:Base:tree.html.twig' %}
 <script type="text/javascript">
+    var apiUrlTemplate = '{{ path('_cmf_get_resource', {
+        repositoryName: repository_name,
+        root_node: root_node,
+        path: '__path__'
+    }|merge(routing_default_values)) }}';
     jQuery(function($) {
         $('#tree').cmfTree({
             request: {
                 load: function (nodePath) {
                     return {
-                        url: '{{ path('_cmf_get_resource', {
-                            repositoryName: repository_name,
-                            root_node: root_node,
-                            path: '__path__'
-                        }|merge(routing_default_values)) }}'.replace('__path__', nodePath)
+                        url: apiUrlTemplate.replace('__path__', nodePath)
                     };
+                },
+                move: function (sourcePath, destinationPath) {
+                    var body = [{"operation": "move", "target": destinationPath}];
+
+                    return $.ajax(
+                      apiUrlTemplate.replace('__path__', sourcePath),
+                      {data: body, method: 'PATCH', dataType: 'json', contentType: 'application/json'}
+                    );
                 }
             },
             actions: {

--- a/Resources/views/Tree/tree.html.twig
+++ b/Resources/views/Tree/tree.html.twig
@@ -36,19 +36,18 @@ file that was distributed with this source code.
                     };
                 },
                 move: function (sourcePath, destinationPath) {
-                    return $.ajax(
-                        apiUrlTemplate.replace('__path__', sourcePath),
-                        {
-                            data: JSON.stringify([{"operation": "move", "target": destinationPath}]),
-                            method: 'PATCH',
-                            dataType: 'json',
-                            contentType: 'application/json; charset=utf-8'
-                        }
-                      ).then(function () {
-                            return $.ajax(apiUrlTemplate.replace('__path__', sourcePath), {dataType: 'json'}).done(function (responseData) {
-                                return responseData;
-                            });
-                      });
+                    return $.when(
+                        $.ajax(
+                            apiUrlTemplate.replace('__path__', sourcePath),
+                            {
+                                 data: JSON.stringify([{"operation": "move", "target": destinationPath}]),
+                                 method: 'PATCH',
+                                 dataType: 'json',
+                                 contentType: 'application/json; charset=utf-8'
+                            }
+                        ),
+                        $.ajax(apiUrlTemplate.replace('__path__', destinationPath), {dataType: 'json'})
+                    );
                 }
             },
             actions: {

--- a/Resources/views/Tree/tree.html.twig
+++ b/Resources/views/Tree/tree.html.twig
@@ -55,14 +55,14 @@ file that was distributed with this source code.
                         return secondResponse.shift();
                     });
                 },
-                reorder: function (parentPath, movedPath, targetPath, position) {
+                reorder: function (parentPath, dropedAtPath, targetPath, position) {
                     return $.when(
                         $.ajax(
                               '{{ path('sonata_admin_tree_reorder') }}',
                               {
                                   data: {
                                     "parent": parentPath,
-                                    "dropped": movedPath,
+                                    "dropped": dropedAtPath,
                                     "target": targetPath,
                                     "position": position
                                   },
@@ -71,7 +71,7 @@ file that was distributed with this source code.
                                   contentType: 'application/x-www-form-urlencoded; charset=UTF-8'
                               }
                         ),
-                        $.ajax(apiGetTemplate.replace('__path__', movedPath), {dataType: 'json'})
+                        $.ajax(apiGetTemplate.replace('__path__', targetPath), {dataType: 'json'})
                     ).then(function (firstResponse, secondResponse) {
                         return secondResponse.shift();
                     });
@@ -89,7 +89,8 @@ file that was distributed with this source code.
                     icon: 'fa fa-trash-o'
                 }
             },
-            dnd: {enabled: true, reorder: true}
+            dnd: {enabled: true, reorder: true},
+            sortableBy: 'position'
         });
     });
 </script>

--- a/Resources/views/Tree/tree.html.twig
+++ b/Resources/views/Tree/tree.html.twig
@@ -44,8 +44,10 @@ file that was distributed with this source code.
                             dataType: 'json',
                             contentType: 'application/json; charset=utf-8'
                         }
-                      ).done(function () {
-                            return $.ajax(apiUrlTemplate.replace('__path__', sourcePath), {dataType: 'json'});
+                      ).then(function () {
+                            return $.ajax(apiUrlTemplate.replace('__path__', sourcePath), {dataType: 'json'}).done(function (responseData) {
+                                return responseData;
+                            });
                       });
                 }
             },

--- a/Resources/views/Tree/tree.html.twig
+++ b/Resources/views/Tree/tree.html.twig
@@ -37,13 +37,16 @@ file that was distributed with this source code.
                 },
                 move: function (sourcePath, destinationPath) {
                     return $.ajax(
-                      apiUrlTemplate.replace('__path__', sourcePath),
-                      {
-                        data: JSON.stringify([{"operation": "move", "target": destinationPath}]),
-                        method: 'PATCH',
-                        dataType: 'json',
-                        contentType: 'application/json; charset=utf-8'}
-                    );
+                        apiUrlTemplate.replace('__path__', sourcePath),
+                        {
+                            data: JSON.stringify([{"operation": "move", "target": destinationPath}]),
+                            method: 'PATCH',
+                            dataType: 'json',
+                            contentType: 'application/json; charset=utf-8'
+                        }
+                      ).done(function () {
+                            return $.ajax(apiUrlTemplate.replace('__path__', sourcePath), {dataType: 'json'});
+                      });
                 }
             },
             actions: {

--- a/Resources/views/Tree/tree.html.twig
+++ b/Resources/views/Tree/tree.html.twig
@@ -55,7 +55,8 @@ file that was distributed with this source code.
                     label: "{{ 'delete_item'|trans({}, 'SonataDoctrinePhpcrAdminBundle') }}",
                     icon: 'fa fa-trash-o'
                 }
-            }
+            },
+            dnd: {enabled: true}
         });
     });
 </script>

--- a/Resources/views/Tree/tree.html.twig
+++ b/Resources/views/Tree/tree.html.twig
@@ -40,14 +40,16 @@ file that was distributed with this source code.
                         $.ajax(
                             apiUrlTemplate.replace('__path__', sourcePath),
                             {
-                                 data: JSON.stringify([{"operation": "move", "target": destinationPath}]),
-                                 method: 'PATCH',
-                                 dataType: 'json',
-                                 contentType: 'application/json; charset=utf-8'
+                                data: JSON.stringify([{"operation": "move", "target": destinationPath}]),
+                                method: 'PATCH',
+                                dataType: 'json',
+                                contentType: 'application/json; charset=utf-8'
                             }
                         ),
                         $.ajax(apiUrlTemplate.replace('__path__', destinationPath), {dataType: 'json'})
-                    );
+                        ).then(function (firstResponse, secondResponse) {
+                            return secondResponse.shift();
+                        });
                 }
             },
             actions: {

--- a/Resources/views/Tree/tree.html.twig
+++ b/Resources/views/Tree/tree.html.twig
@@ -60,15 +60,15 @@ file that was distributed with this source code.
                         $.ajax(
                               '{{ path('sonata_admin_tree_reorder') }}',
                               {
-                                  data: JSON.stringify([{
+                                  data: {
                                     "parent": parentPath,
                                     "dropped": movedPath,
                                     "target": targetPath,
                                     "position": position
-                                  }]),
+                                  },
                                   method: 'POST',
                                   dataType: 'json',
-                                  contentType: 'application/json; charset=utf-8'
+                                  contentType: 'application/x-www-form-urlencoded; charset=UTF-8'
                               }
                         ),
                         $.ajax(apiGetTemplate.replace('__path__', movedPath), {dataType: 'json'})

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "symfony/property-access": "^2.8 || ^3.0"
     },
     "require-dev": {
-        "dantleech/glob-finder": "@dev",
+        "dantleech/glob-finder": "1.*",
         "jackalope/jackalope-jackrabbit": "^1.0",
         "puli/repository": "@beta",
         "sllh/php-cs-fixer-styleci-bridge": "^2.0",


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 1.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrinePhpcrAdminBundle/blob/1.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because it should get into 2.0@dev

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #434 
fix #434, https://github.com/symfony-cmf/tree-browser-bundle/issues/146, https://github.com/symfony-cmf/tree-browser-bundle/issues/139

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added options (implementation of move) passed to the tree, to enable drag&drop. 
```

## Subject

<!-- Describe your Pull Request content here -->
We had problems to see drag&drop working on the tree, now it should work again. treebrowser needed an implementation of the `move` on the tree repository. This is done by two ajax requests now.

## ToDo

* [x] move here and in tree-browser
* [x] reorder in Backend
* [x] reorder works in tree browser
* [ ] answers on questions
