### PR TITLE
trying to fix lowest-version build

### DIFF
--- a/.travis/install_test.sh
+++ b/.travis/install_test.sh
@@ -18,6 +18,7 @@ chmod u+x "${HOME}/bin/coveralls"
 
 # To be removed when this issue will be resolved: https://github.com/composer/composer/issues/5355
 if [ "${COMPOSER_FLAGS}" = '--prefer-lowest' ]; then
-    composer update --prefer-dist --no-interaction --prefer-stable --quiet
+    composer require --no-install symfony/framework-bundle 2.8.*
+    composer require --no-install doctrine/phpcr-odm 1.1.*
 fi
 composer update --prefer-dist --no-interaction --prefer-stable ${COMPOSER_FLAGS}

--- a/.travis/install_test.sh
+++ b/.travis/install_test.sh
@@ -18,7 +18,6 @@ chmod u+x "${HOME}/bin/coveralls"
 
 # To be removed when this issue will be resolved: https://github.com/composer/composer/issues/5355
 if [ "${COMPOSER_FLAGS}" = '--prefer-lowest' ]; then
-    composer require --no-install symfony/framework-bundle 2.8.*
-    composer require --no-install doctrine/phpcr-odm 1.1.*
+    composer update --prefer-dist --no-interaction --prefer-stable --quiet
 fi
-composer update --prefer-dist --no-interaction --prefer-stable ${COMPOSER_FLAGS}
+travis_wait composer update --prefer-dist --no-interaction --prefer-stable ${COMPOSER_FLAGS}


### PR DESCRIPTION
on master, the lowest-version build times out (#440). trying to see if restricting the dependencies a bit helps composer find a solution.

this is not mergeable because .travis/ is managed by dev-kit...