### PR TITLE
adjust lowest php version to the cmf project and build matrix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^5.5 || ^7.0",
+        "php": "^5.6 || ^7.0",
         "doctrine/phpcr-bundle": "^1.1",
         "doctrine/phpcr-odm": "^1.1 || ^2.0",
         "sonata-project/admin-bundle": "^3.1",


### PR DESCRIPTION
fix #447 

the build matrix from dev-kit already is at php 5.6