### PR TITLE
Bump every dep to its latest patch version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,13 +17,13 @@
     ],
     "require": {
         "php": "^5.3.3 || ^7.0",
-        "doctrine/phpcr-bundle": "^1.1",
-        "doctrine/phpcr-odm": "^1.1",
+        "doctrine/phpcr-bundle": "^1.1.2",
+        "doctrine/phpcr-odm": "^1.1.4",
         "sonata-project/admin-bundle": "^2.2.9",
         "sonata-project/jquery-bundle": "1.8.*",
-        "symfony-cmf/tree-browser-bundle": "^1.0",
-        "symfony/framework-bundle": "^2.3",
-        "symfony/property-access": "^2.2"
+        "symfony-cmf/tree-browser-bundle": "^1.0.3",
+        "symfony/framework-bundle": "^2.3.42",
+        "symfony/property-access": "^2.2.11"
     },
     "require-dev": {
         "jackalope/jackalope-jackrabbit": "^1.0",


### PR DESCRIPTION
This will reduce the space of possible versions and hopefully, fix the
prefer-lowest build.