### PR TITLE
[do not merge] demo hhvm build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ php:
   - '7.0'
   - '7.1'
   - nightly
-  - hhvm
 
 sudo: false
 
@@ -58,6 +57,8 @@ matrix:
       env: SONATA_BLOCK=dev-master@dev
     - php: '7.1'
       env: SYMFONY_DEPRECATIONS_HELPER=0
+    - php: hhvm
+      dist: trusty
   allow_failures:
     - php: nightly
     - php: hhvm


### PR DESCRIPTION
show that the changes in https://github.com/sonata-project/dev-kit/pull/250 will fix the problem.

you need to look at the travis page in the allowed-failures section, even if hhvm does not work the build status will be green as its allowed to fail.