### PR TITLE
Missing parameter

### DIFF
--- a/src/Controller/TreeController.php
+++ b/src/Controller/TreeController.php
@@ -76,7 +76,7 @@ class TreeController extends Controller
 
         return $this->render($this->template, array(
             'root_node' => $root,
-            'routing_defaults' => $this->treeConfiguration['routing_default'],
+            'routing_defaults' => $this->treeConfiguration['routing_defaults'],
             'repository_name' => $this->treeConfiguration['repository_name'],
             'reorder' => $this->treeConfiguration['reorder'],
             'move' => $this->treeConfiguration['move'],

--- a/src/DependencyInjection/SonataDoctrinePHPCRAdminExtension.php
+++ b/src/DependencyInjection/SonataDoctrinePHPCRAdminExtension.php
@@ -101,5 +101,9 @@ class SonataDoctrinePHPCRAdminExtension extends AbstractSonataAdminExtension
         );
 
         $container->setParameter('sonata_admin_doctrine_phpcr.tree_block.configuration', $configuration);
+
+        foreach ($configuration as $key => $value) {
+            $container->setParameter('sonata_admin_doctrine_phpcr.tree_block.'.$key, $value);
+        }
     }
 }

--- a/src/Resources/config/block.xml
+++ b/src/Resources/config/block.xml
@@ -8,7 +8,7 @@
             <tag name="sonata.block"/>
             <argument>sonata_admin_doctrine_phpcr.tree_block</argument>
             <argument type="service" id="templating"/>
-            <argument>%sonata_admin_doctrine_phpcr.tree_block.defaults%</argument>
+            <argument>%sonata_admin_doctrine_phpcr.tree_block.routing_defaults%</argument>
         </service>
     </services>
 </container>

--- a/src/Resources/config/doctrine_phpcr_form_types.xml
+++ b/src/Resources/config/doctrine_phpcr_form_types.xml
@@ -4,7 +4,7 @@
         <service id="sonata.admin.doctrine_phpcr.form.type.phpcr_odm_tree" class="Sonata\DoctrinePHPCRAdminBundle\Form\Type\TreeModelType">
             <tag name="form.type" alias="doctrine_phpcr_odm_tree"/>
             <call method="setDefaults">
-                <argument>%sonata_admin_doctrine_phpcr.tree_block.defaults%</argument>
+                <argument>%sonata_admin_doctrine_phpcr.tree_block.routing_defaults%</argument>
             </call>
         </service>
         <service id="sonata.admin.doctrine_phpcr.form.type.phpcr_odm_tree_manager" class="Sonata\DoctrinePHPCRAdminBundle\Form\Type\TreeManagerType">

--- a/tests/DependencyInjection/SonataDoctrinePHPCRAdminExtensionTest.php
+++ b/tests/DependencyInjection/SonataDoctrinePHPCRAdminExtensionTest.php
@@ -41,5 +41,26 @@ class SonataDoctrinePHPCRAdminExtensionTest extends AbstractExtensionTestCase
                 'reorder' => true,
             )
         );
+
+        $this->assertContainerBuilderHasParameter(
+            'sonata_admin_doctrine_phpcr.tree_block.routing_defaults',
+            array()
+        );
+        $this->assertContainerBuilderHasParameter(
+            'sonata_admin_doctrine_phpcr.tree_block.repository_name',
+            null
+        );
+        $this->assertContainerBuilderHasParameter(
+            'sonata_admin_doctrine_phpcr.tree_block.sortable_by',
+            'position'
+        );
+        $this->assertContainerBuilderHasParameter(
+            'sonata_admin_doctrine_phpcr.tree_block.move',
+            true
+        );
+        $this->assertContainerBuilderHasParameter(
+            'sonata_admin_doctrine_phpcr.tree_block.reorder',
+            true
+        );
     }
 }


### PR DESCRIPTION
This one uses the moved parameter. I led to an [error](https://travis-ci.org/symfony-cmf/sonata-phpcr-admin-integration-bundle/builds/258322770?utm_source=github_status&utm_medium=notification) on our `sonata-phpcr-admin-integration-bundle`.