### PR TITLE
Fix template var setting

### DIFF
--- a/src/Resources/views/Tree/tree.html.twig
+++ b/src/Resources/views/Tree/tree.html.twig
@@ -90,7 +90,7 @@ file that was distributed with this source code.
                 }
             },
             dnd: {enabled: {{ move  }}, reorder: {{ reorder }}},
-            sortableBy: {{ sortable_by  }}
+            sortableBy: '{{ sortable_by  }}'
         });
     });
 </script>


### PR DESCRIPTION
This one breaks the current admin view of the tree. The missing `'`.