### PR TITLE
Remove script that dev-kit failed to remove

### DIFF
--- a/.travis/before_script_test.sh
+++ b/.travis/before_script_test.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env sh
-set -ev
-
-if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then
-    mv /tmp/xdebug.ini "$HOME/.phpenv/versions/$(phpenv version-name)/etc/conf.d"
-fi


### PR DESCRIPTION
Should have been removed after
https://github.com/sonata-project/dev-kit/commit/d97e753e0bf5df071b344705f7115905b77c15b6
but wasn't.
