### PR TITLE
Fix tree root node

### DIFF
--- a/src/Resources/views/Tree/tree.html.twig
+++ b/src/Resources/views/Tree/tree.html.twig
@@ -24,11 +24,11 @@ file that was distributed with this source code.
 <script type="text/javascript">
     var apiGetTemplate = '{{ path('_cmf_get_resource', {
         repositoryName: repository_name,
-        root_node: root_node,
         path: '__path__'
     }|merge(routing_default_values)) }}';
     jQuery(function($) {
         $('#tree').cmfTree({
+            root_node: '{{ root_node }}',
             request: {
                 load: function (nodePath) {
                     return {
@@ -38,11 +38,7 @@ file that was distributed with this source code.
                 move: function (sourcePath, destinationPath) {
                     return $.when(
                         $.ajax(
-                            '{{ path('_cmf_patch_resource', {
-                                repositoryName: repository_name,
-                                root_node: root_node,
-                                path: '__path__'
-                            }|merge(routing_default_values)) }}'.replace('__path__', sourcePath),
+                            apiGetTemplate.replace('__path__', sourcePath),
                             {
                                 data: JSON.stringify([{"operation": "move", "target": destinationPath}]),
                                 method: 'PATCH',


### PR DESCRIPTION
## Changelog

```markdown
### Fixed
- Missing root_node parameter in cmfTree options
```

## Subject

Hi ! I try to update to cmf 2.0. I'm not comfortable with the tree JS, but I think there is an issue with the cmfTree root_node parameter. Here are the results before/after the fix :

| Before  | After |
| ------------- | ------------- |
| ![before](https://user-images.githubusercontent.com/663607/29620255-b99c269a-881d-11e7-84f0-5cc038daa704.JPG) | ![after](https://user-images.githubusercontent.com/663607/29620256-b99f1e5e-881d-11e7-96a1-8e1be861326a.JPG) |