### PR TITLE
Drop old versions of php/sf

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,15 +16,15 @@
         }
     ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.1",
         "doctrine/phpcr-bundle": "^1.1",
         "doctrine/phpcr-odm": "^1.3 || ^2.0",
         "sonata-project/admin-bundle": "^3.21.0",
         "sonata-project/block-bundle": "^3.0",
         "symfony-cmf/resource-rest-bundle": "^1.0",
         "symfony-cmf/tree-browser-bundle": "^2.0",
-        "symfony/framework-bundle": "^2.8 || ^3.0",
-        "symfony/property-access": "^2.8 || ^3.0"
+        "symfony/framework-bundle": "^2.8 || ^3.2",
+        "symfony/property-access": "^2.8 || ^3.2"
     },
     "require-dev": {
         "dantleech/glob-finder": "1.*",
@@ -36,8 +36,8 @@
         "symfony-cmf/resource": "^1.0",
         "symfony-cmf/resource-bundle": "^1.0",
         "symfony-cmf/testing": "^2.0",
-        "symfony/phpunit-bridge": "^2.8 || ^3.0",
-        "symfony/security-acl": "^2.8 || ^3.0"
+        "symfony/phpunit-bridge": "^3.3",
+        "symfony/security-acl": "^2.8 || ^3.2"
     },
     "provide": {
         "sonata-project/admin-bundle-persistency-layer": "1.0.0"

--- a/src/Form/Type/Filter/ChoiceType.php
+++ b/src/Form/Type/Filter/ChoiceType.php
@@ -12,8 +12,8 @@
 namespace Sonata\DoctrinePHPCRAdminBundle\Form\Type\Filter;
 
 use Sonata\AdminBundle\Form\Type\Filter\ChoiceType as BaseChoiceType;
-use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType as SymfonyChoiceType;
+use Symfony\Component\Form\FormBuilderInterface;
 
 class ChoiceType extends BaseChoiceType
 {
@@ -42,19 +42,19 @@ class ChoiceType extends BaseChoiceType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $choices = array(
-            self::TYPE_CONTAINS => $this->translator->trans('label_type_contains', array(), 'SonataAdminBundle'),
-            self::TYPE_NOT_CONTAINS => $this->translator->trans('label_type_not_contains', array(), 'SonataAdminBundle'),
-            self::TYPE_EQUAL => $this->translator->trans('label_type_equals', array(), 'SonataAdminBundle'),
-            self::TYPE_CONTAINS_WORDS => $this->translator->trans('label_type_contains_words', array(), 'SonataDoctrinePHPCRAdmin'),
-        );
+        $choices = [
+            self::TYPE_CONTAINS => $this->translator->trans('label_type_contains', [], 'SonataAdminBundle'),
+            self::TYPE_NOT_CONTAINS => $this->translator->trans('label_type_not_contains', [], 'SonataAdminBundle'),
+            self::TYPE_EQUAL => $this->translator->trans('label_type_equals', [], 'SonataAdminBundle'),
+            self::TYPE_CONTAINS_WORDS => $this->translator->trans('label_type_contains_words', [], 'SonataDoctrinePHPCRAdmin'),
+        ];
 
         $builder
-            ->add('type', SymfonyChoiceType::class, array(
+            ->add('type', SymfonyChoiceType::class, [
                 'choices' => $choices,
                 'required' => false,
-            ))
-            ->add('value', $options['field_type'], array_merge(array('required' => false), $options['field_options']))
+            ])
+            ->add('value', $options['field_type'], array_merge(['required' => false], $options['field_options']))
         ;
     }
 }

--- a/src/Form/Type/Filter/ChoiceType.php
+++ b/src/Form/Type/Filter/ChoiceType.php
@@ -13,6 +13,7 @@ namespace Sonata\DoctrinePHPCRAdminBundle\Form\Type\Filter;
 
 use Sonata\AdminBundle\Form\Type\Filter\ChoiceType as BaseChoiceType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType as SymfonyChoiceType;
 
 class ChoiceType extends BaseChoiceType
 {
@@ -49,7 +50,10 @@ class ChoiceType extends BaseChoiceType
         );
 
         $builder
-            ->add('type', 'Symfony\Component\Form\Extension\Core\Type\ChoiceType', array('choices' => $choices, 'required' => false))
+            ->add('type', SymfonyChoiceType::class, array(
+                'choices' => $choices,
+                'required' => false,
+            ))
             ->add('value', $options['field_type'], array_merge(array('required' => false), $options['field_options']))
         ;
     }


### PR DESCRIPTION
I am targeting this branch, because this is BC.

## Changelog

```markdown
### Removed
- Support for old versions of PHP and Symfony.
```
