### PR TITLE
Drop PHPUnit 4

### DIFF
--- a/tests/Unit/Admin/AdminTest.php
+++ b/tests/Unit/Admin/AdminTest.php
@@ -11,9 +11,10 @@
 
 namespace Sonata\DoctrinePHPCRAdminBundle\Tests\Unit\Admin;
 
+use PHPUnit\Framework\TestCase;
 use Sonata\DoctrinePHPCRAdminBundle\Admin\Admin;
 
-class AdminTest extends \PHPUnit_Framework_TestCase
+class AdminTest extends TestCase
 {
     public function testItCanBeInstanciated()
     {

--- a/tests/Unit/Builder/ListBuilderTest.php
+++ b/tests/Unit/Builder/ListBuilderTest.php
@@ -11,6 +11,7 @@
 
 namespace Sonata\DoctrinePHPCRAdminBundle\Tests\Unit\Builder;
 
+use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Admin\FieldDescriptionCollection;
 use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\AdminBundle\Guesser\TypeGuesserInterface;
@@ -21,7 +22,7 @@ use Sonata\DoctrinePHPCRAdminBundle\Model\ModelManager;
 use Symfony\Component\Form\Guess\Guess;
 use Symfony\Component\Form\Guess\TypeGuess;
 
-class ListBuilderTest extends \PHPUnit_Framework_TestCase
+class ListBuilderTest extends TestCase
 {
     /**
      * @var ListBuilder
@@ -120,9 +121,9 @@ class ListBuilderTest extends \PHPUnit_Framework_TestCase
 
     //public function testAddField()
     //{
-    //    $fieldDescriptionCollection = $this->getMock('\Sonata\AdminBundle\Admin\FieldDescriptionCollection', array(), array());
-    //    $fieldDescription = $this->getMock('\Sonata\AdminBundle\Admin\FieldDescriptionInterface', array(), array());
-    //    $admin = $this->getMock('\Sonata\AdminBundle\Admin\AdminInterface', array(), array());
+    //    $fieldDescriptionCollection = $this->createMock('\Sonata\AdminBundle\Admin\FieldDescriptionCollection', array(), array());
+    //    $fieldDescription = $this->createMock('\Sonata\AdminBundle\Admin\FieldDescriptionInterface', array(), array());
+    //    $admin = $this->createMock('\Sonata\AdminBundle\Admin\AdminInterface', array(), array());
     //    $lb = new ListBuilder($this->guesser, $this->templates);
 
     //    $lb->addField($fieldDescriptionCollection, 'sometype', $fieldDescription, $admin);

--- a/tests/Unit/Builder/ListBuilderTest.php
+++ b/tests/Unit/Builder/ListBuilderTest.php
@@ -56,8 +56,8 @@ class ListBuilderTest extends TestCase
 
     public function setUp()
     {
-        $this->guesser = $this->createMock('\Sonata\AdminBundle\Guesser\TypeGuesserInterface', array(), array());
-        $this->templates = array();
+        $this->guesser = $this->createMock('\Sonata\AdminBundle\Guesser\TypeGuesserInterface', [], []);
+        $this->templates = [];
     }
 
     public function testGetBaseList()
@@ -74,7 +74,7 @@ class ListBuilderTest extends TestCase
 
     public function testAddFieldNullType()
     {
-        $typeguess = $this->createMock('Symfony\Component\Form\Guess\TypeGuess', array(), array(), '', false);
+        $typeguess = $this->createMock('Symfony\Component\Form\Guess\TypeGuess', [], [], '', false);
         $this->guesser->expects($this->once())
             ->method('guessType')
             ->with($this->anything())
@@ -105,7 +105,7 @@ class ListBuilderTest extends TestCase
         $this->setUpListActionTests();
 
         $this->guesser->expects($this->once())->method('guessType')
-            ->willReturn(new TypeGuess(null, array(), Guess::LOW_CONFIDENCE));
+            ->willReturn(new TypeGuess(null, [], Guess::LOW_CONFIDENCE));
 
         $fieldDescription = new FieldDescription();
         $fieldDescription->setName('_action');
@@ -121,9 +121,9 @@ class ListBuilderTest extends TestCase
 
     //public function testAddField()
     //{
-    //    $fieldDescriptionCollection = $this->createMock('\Sonata\AdminBundle\Admin\FieldDescriptionCollection', array(), array());
-    //    $fieldDescription = $this->createMock('\Sonata\AdminBundle\Admin\FieldDescriptionInterface', array(), array());
-    //    $admin = $this->createMock('\Sonata\AdminBundle\Admin\AdminInterface', array(), array());
+    //    $fieldDescriptionCollection = $this->createMock('\Sonata\AdminBundle\Admin\FieldDescriptionCollection', [], []);
+    //    $fieldDescription = $this->createMock('\Sonata\AdminBundle\Admin\FieldDescriptionInterface', [], []);
+    //    $admin = $this->createMock('\Sonata\AdminBundle\Admin\AdminInterface', [], []);
     //    $lb = new ListBuilder($this->guesser, $this->templates);
 
     //    $lb->addField($fieldDescriptionCollection, 'sometype', $fieldDescription, $admin);
@@ -142,7 +142,7 @@ class ListBuilderTest extends TestCase
             ->with($this->anything())
             ->will($this->returnValue(true));
 
-        $this->admin = $this->createMock('\Sonata\AdminBundle\Admin\Admin', array(), array(), '', false);
+        $this->admin = $this->createMock('\Sonata\AdminBundle\Admin\Admin', [], [], '', false);
         $this->admin->expects($this->atLeastOnce())->method('getModelManager')
             ->willReturn($this->modelManager);
 
@@ -152,7 +152,7 @@ class ListBuilderTest extends TestCase
     private function setupAddField()
     {
         $this->lb = new ListBuilder($this->guesser, $this->templates);
-        $this->metaData = $this->createMock('\Doctrine\ODM\PHPCR\Mapping\ClassMetadata', array(), array(), '', false);
+        $this->metaData = $this->createMock('\Doctrine\ODM\PHPCR\Mapping\ClassMetadata', [], [], '', false);
         $this->modelManager = $this->createMock('\Sonata\DoctrinePHPCRAdminBundle\Model\ModelManager');
         $this->modelManager->expects($this->any())
             ->method('getMetadata')
@@ -172,7 +172,7 @@ class ListBuilderTest extends TestCase
 
         //AdminInterface doesn't implement methods called in addField,
         //so we mock Admin
-        $this->admin = $this->createMock('\Sonata\AdminBundle\Admin\AbstractAdmin', array(), array(), '', false);
+        $this->admin = $this->createMock('\Sonata\AdminBundle\Admin\AbstractAdmin', [], [], '', false);
         $this->admin->expects($this->any())
             ->method('getModelManager')
             ->will($this->returnValue($this->modelManager));

--- a/tests/Unit/Datagrid/PagerTest.php
+++ b/tests/Unit/Datagrid/PagerTest.php
@@ -12,9 +12,10 @@
 namespace Sonata\DoctrinePHPCRAdminBundle\Tests\Unit\Datagrid;
 
 use Doctrine\ODM\PHPCR\Query\Query as PHPCRQuery;
+use PHPUnit\Framework\TestCase;
 use Sonata\DoctrinePHPCRAdminBundle\Datagrid\Pager;
 
-class PagerTest extends \PHPUnit_Framework_TestCase
+class PagerTest extends TestCase
 {
     public function setUp()
     {

--- a/tests/Unit/Datagrid/PagerTest.php
+++ b/tests/Unit/Datagrid/PagerTest.php
@@ -30,7 +30,7 @@ class PagerTest extends TestCase
     {
         $this->proxyQuery->expects($this->once())
             ->method('execute')
-            ->with(array(), PHPCRQuery::HYDRATE_PHPCR)
+            ->with([], PHPCRQuery::HYDRATE_PHPCR)
             ->will($this->returnValue(range(0, 12)));
 
         $this->proxyQuery->expects($this->once())
@@ -51,7 +51,7 @@ class PagerTest extends TestCase
     {
         $this->proxyQuery->expects($this->once())
             ->method('execute')
-            ->with(array(), PHPCRQuery::HYDRATE_PHPCR)
+            ->with([], PHPCRQuery::HYDRATE_PHPCR)
             ->will($this->returnValue(range(0, 12)));
 
         $this->proxyQuery->expects($this->once())
@@ -93,8 +93,8 @@ class PagerTest extends TestCase
     {
         $this->proxyQuery->expects($this->once())
             ->method('execute')
-            ->with(array(), PHPCRQuery::HYDRATE_PHPCR)
-            ->will($this->returnValue(array()));
+            ->with([], PHPCRQuery::HYDRATE_PHPCR)
+            ->will($this->returnValue([]));
 
         $this->proxyQuery->expects($this->once())
             ->method('setMaxResults')

--- a/tests/Unit/Datagrid/ProxyQueryTest.php
+++ b/tests/Unit/Datagrid/ProxyQueryTest.php
@@ -46,7 +46,7 @@ class ProxyQueryTest extends TestCase
 
     public function testSetSortBy()
     {
-        $this->pq->setSortBy(array(), array('fieldName' => 'field'));
+        $this->pq->setSortBy([], ['fieldName' => 'field']);
         $this->assertEquals('field', $this->pq->getSortBy());
     }
 

--- a/tests/Unit/Datagrid/ProxyQueryTest.php
+++ b/tests/Unit/Datagrid/ProxyQueryTest.php
@@ -12,9 +12,10 @@
 namespace Sonata\DoctrinePHPCRAdminBundle\Tests\Unit\Datagrid;
 
 use Doctrine\ODM\PHPCR\Query\Builder\QueryBuilder;
+use PHPUnit\Framework\TestCase;
 use Sonata\DoctrinePHPCRAdminBundle\Datagrid\ProxyQuery;
 
-class ProxyQueryTest extends \PHPUnit_Framework_TestCase
+class ProxyQueryTest extends TestCase
 {
     /**
      * @var QueryBuilder|\PHPUnit_Framework_MockObject_MockObject

--- a/tests/Unit/Filter/BaseTestCase.php
+++ b/tests/Unit/Filter/BaseTestCase.php
@@ -13,9 +13,10 @@ namespace Sonata\DoctrinePHPCRAdminBundle\Tests\Unit\Filter;
 
 use Doctrine\ODM\PHPCR\Query\Builder\QueryBuilder;
 use Doctrine\ODM\PHPCR\Tools\Test\QueryBuilderTester;
+use PHPUnit\Framework\TestCase;
 use Sonata\DoctrinePHPCRAdminBundle\Datagrid\ProxyQuery;
 
-class BaseTestCase extends \PHPUnit_Framework_TestCase
+class BaseTestCase extends TestCase
 {
     /**
      * @var QueryBuilder

--- a/tests/Unit/Guesser/FilterTypeGuesserTest.php
+++ b/tests/Unit/Guesser/FilterTypeGuesserTest.php
@@ -32,7 +32,7 @@ class FilterTypeGuesserTest extends TestCase
 
         $managerRegistry->expects($this->once())
             ->method('getManagers')
-            ->will($this->returnValue(array($documentRepository)));
+            ->will($this->returnValue([$documentRepository]));
 
         $guesser = new FilterTypeGuesser(
             $managerRegistry
@@ -51,12 +51,12 @@ class FilterTypeGuesserTest extends TestCase
             $typeGuess->getType()
         );
         $this->assertSame(
-            array(
+            [
                 'field_type' => 'Symfony\Component\Form\Extension\Core\Type\TextType',
-                'field_options' => array(),
-                'options' => array(),
+                'field_options' => [],
+                'options' => [],
                 'field_name' => $fieldname,
-            ),
+            ],
             $typeGuess->getOptions()
         );
 

--- a/tests/Unit/Guesser/FilterTypeGuesserTest.php
+++ b/tests/Unit/Guesser/FilterTypeGuesserTest.php
@@ -11,10 +11,11 @@
 
 namespace Sonata\DoctrinePHPCRAdminBundle\Tests\Unit\Guesser;
 
+use PHPUnit\Framework\TestCase;
 use Sonata\DoctrinePHPCRAdminBundle\Guesser\FilterTypeGuesser;
 use Symfony\Component\Form\Guess\Guess;
 
-class FilterTypeGuesserTest extends \PHPUnit_Framework_TestCase
+class FilterTypeGuesserTest extends TestCase
 {
     public function testGuessType()
     {

--- a/tests/Unit/Route/PathInfoBuilderSlashesTest.php
+++ b/tests/Unit/Route/PathInfoBuilderSlashesTest.php
@@ -28,7 +28,7 @@ class PathInfoBuilderSlashesTest extends TestCase
         $admin = $this->createMock('Sonata\\AdminBundle\\Admin\\AbstractAdmin');
         $admin->expects($this->once())
             ->method('getChildren')
-            ->will($this->returnValue(array($adminChild)));
+            ->will($this->returnValue([$adminChild]));
 
         $collection = $this->createMock('Sonata\\AdminBundle\\Route\\RouteCollection');
         $collection->expects($this->once())
@@ -47,7 +47,7 @@ class PathInfoBuilderSlashesTest extends TestCase
         $admin = $this->createMock('Sonata\\AdminBundle\\Admin\\AbstractAdmin');
         $admin->expects($this->once())
             ->method('getChildren')
-            ->will($this->returnValue(array()));
+            ->will($this->returnValue([]));
         $admin->expects($this->once())
             ->method('isAclEnabled')
             ->will($this->returnValue(true));

--- a/tests/Unit/Route/PathInfoBuilderSlashesTest.php
+++ b/tests/Unit/Route/PathInfoBuilderSlashesTest.php
@@ -11,9 +11,10 @@
 
 namespace Sonata\DoctrinePHPCRAdminBundle\Tests\Unit\Route;
 
+use PHPUnit\Framework\TestCase;
 use Sonata\DoctrinePHPCRAdminBundle\Route\PathInfoBuilderSlashes;
 
-class PathInfoBuilderSlashesTest extends \PHPUnit_Framework_TestCase
+class PathInfoBuilderSlashesTest extends TestCase
 {
     public function testBuild()
     {


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataNewsBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Subject

<!-- Describe your Pull Request content here -->
Removed compatibility with PHPUnit 4. Fixes: https://github.com/sebastianbergmann/phpunit/issues/2809