### PR TITLE
Avoid loop

### DIFF
--- a/src/Admin/Admin.php
+++ b/src/Admin/Admin.php
@@ -98,7 +98,7 @@ class Admin extends AbstractAdmin
                 if (!UUIDHelper::isUUID($id)) {
                     $id = PathHelper::absolutizePath($id, '/');
                 }
-                $this->subject = $this->getModelManager()->find($this->getClass(), $id);
+                $this->subject = $this->getObject($id);
             }
         }
 


### PR DESCRIPTION
I am targeting this branch, because i face the loop in here

## Changelog

```markdown
### Changed
- getSubject() implementation calls `AbstractAdmin::getObject()` now to avoid calling `getClass()`
```

## Subject

In our test we hit a loop, cause we had to implement getSubject() on our own, where we used getClass(), which calls getSubject() again.
