### PR TITLE
Update symfony-cmf/resource-rest-bundle dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "doctrine/phpcr-odm": "^1.4 || ^2.0",
         "sonata-project/admin-bundle": "^3.30.1",
         "sonata-project/block-bundle": "^3.9",
-        "symfony-cmf/resource-rest-bundle": "^1.0",
+        "symfony-cmf/resource-rest-bundle": "^1.0.1",
         "symfony-cmf/tree-browser-bundle": "^2.0",
         "symfony/config": "^2.8 || ^3.2",
         "symfony/dependency-injection": "^2.8 || ^3.2",


### PR DESCRIPTION
I am targeting this branch, because this is a patch.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed

- Update symfony-cmf/resource-rest-bundle dependency
```

## To do

- [x] Test `1.0.0`
- [x] Test `^1.0.1`

## Subject

Travis for https://github.com/sonata-project/SonataDoctrinePhpcrAdminBundle/pull/517 failed because package `symfony-cmf/resource-rest-bundle` v1.0.0 were used there