### PR TITLE
Update composer deps for 2.x dev kit

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug.md
+++ b/.github/ISSUE_TEMPLATE/Bug.md
@@ -1,0 +1,57 @@
+---
+name: 🐞 Bug Report
+about: Something is broken? 🔨
+---
+
+<!--
+    Before you open an issue, make sure this one does not already exist.
+    Please also read the "guidelines for contributing" link above before posting.
+-->
+
+<!--
+    If you are reporting a bug, please try to fill in the following.
+    Otherwise remove it.
+-->
+
+### Environment
+
+#### Sonata packages
+
+```
+$ composer show --latest 'sonata-project/*'
+# Put the result here.
+```
+
+#### Symfony packages
+
+```
+$ composer show --latest 'symfony/*'
+# Put the result here.
+```
+
+#### PHP version
+
+```
+$ php -v
+# Put the result here.
+```
+
+## Subject
+
+<!--
+    Give here as many details as possible.
+    Next sections are for ERRORS only.
+-->
+
+## Steps to reproduce
+
+## Expected results
+
+## Actual results
+
+<!--
+    If it's an error message or piece of code, use code block tags,
+    and make sure you provide the whole stack trace(s),
+    not just the first error message you can see.
+    More details here: https://github.com/sonata-project/SonataDoctrinePhpcrAdminBundle/blob/2.x/CONTRIBUTING.md#issues
+-->

--- a/.github/ISSUE_TEMPLATE/Feature.md
+++ b/.github/ISSUE_TEMPLATE/Feature.md
@@ -1,0 +1,8 @@
+---
+name: 🚀 Feature Request
+about: I have a suggestion (and may want to implement it 🙂)!
+---
+
+## Feature Request
+
+<!-- Provide a summary of the feature. -->

--- a/.github/ISSUE_TEMPLATE/Question.md
+++ b/.github/ISSUE_TEMPLATE/Question.md
@@ -1,0 +1,7 @@
+---
+name: ⛔ NO support questions
+about: If you have a question, please check out our Slack or StackOverflow!
+---
+
+Hi, we try to keep Github issues for bug reports and feature requests only.
+If you have a question, please ask it on Stack Overflow or on #sonata on [the symfony-devs slack](https://symfony.com/slack-invite).

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -23,6 +23,12 @@ Closes #{put_issue_number_here}
     Follow this schema: http://keepachangelog.com/
 -->
 
+<!-- 
+    If you are updating something that doesn't require
+    a release, you can delete whole Changelog section.
+    (eg. update to docs, tests)
+-->
+
 <!-- REMOVE EMPTY SECTIONS -->
 ```markdown
 ### Added
@@ -39,17 +45,17 @@ Closes #{put_issue_number_here}
 ### Security
 ```
 
-## To do
-
 <!--
-    If this is a work in progress, COMPLETE and ADD needed tasks.
+    If this is a work in progress, uncomment this section.
     You can add as many tasks as you want.
-    If some are not relevant, just REMOVE them.
+    If some are not relevant, just remove them.
+    
+    ## To do
+    
+    - [ ] Update the tests
+    - [ ] Update the documentation
+    - [ ] Add an upgrade note
 -->
-
-- [ ] Update the tests
-- [ ] Update the documentation
-- [ ] Add an upgrade note
 
 ## Subject
 

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -26,7 +26,7 @@ $rules = [
     'header_comment' => [
         'header' => $header,
     ],
-    'no_extra_consecutive_blank_lines' => true,
+    'no_extra_blank_lines' => true,
     'no_php4_constructor' => true,
     'no_useless_else' => true,
     'no_useless_return' => true,

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ cache:
 env:
   global:
     - PATH="$HOME/.local/bin:$PATH"
-    - SYMFONY_DEPRECATIONS_HELPER=weak
+    - SYMFONY_DEPRECATIONS_HELPER=weak_vendors
     - TARGET=test
     - UPSTREAM_URL=https://github.com/sonata-project/SonataDoctrinePhpcrAdminBundle.git
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2010-2016 Thomas Rabaix
+Copyright (c) 2010 Thomas Rabaix
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ lint-composer:
 .PHONY: lint-composer
 
 lint-yaml:
-	find . -name '*.yml' -not -path './vendor/*' -not -path './src/Resources/public/vendor/*' | xargs yaml-lint
+	yaml-lint --ignore-non-yaml-files --quiet --exclude vendor .
 
 .PHONY: lint-yaml
 

--- a/composer.json
+++ b/composer.json
@@ -44,6 +44,8 @@
         "dantleech/glob-finder": "^1.0",
         "jackalope/jackalope-jackrabbit": "^1.3",
         "matthiasnoback/symfony-dependency-injection-test": "^1.1",
+        "phpcr/phpcr": "^2.1",
+        "phpcr/phpcr-utils": "^1.4.0",
         "sonata-project/core-bundle": "^3.8",
         "symfony-cmf/resource": "^1.0",
         "symfony-cmf/resource-bundle": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
         "sonata-project/core-bundle": "^3.8",
         "symfony-cmf/resource": "^1.0",
         "symfony-cmf/resource-bundle": "^1.0",
-        "symfony-cmf/testing": "^2.0.1",
+        "symfony-cmf/testing": "2.0.*",
         "symfony/phpunit-bridge": "^4.0",
         "symfony/routing": "^2.8 || ^3.2",
         "symfony/security-acl": "^2.8 || ^3.0"

--- a/src/Builder/DatagridBuilder.php
+++ b/src/Builder/DatagridBuilder.php
@@ -101,7 +101,7 @@ class DatagridBuilder implements DatagridBuilderInterface
             if (isset($metadata->mappings[$fieldDescription->getName()])) {
                 $fieldDescription->setFieldMapping($metadata->mappings[$fieldDescription->getName()]);
 
-                if ($metadata->mappings[$fieldDescription->getName()]['type'] == 'string') {
+                if ('string' == $metadata->mappings[$fieldDescription->getName()]['type']) {
                     $fieldDescription->setOption('global_search', $fieldDescription->getOption('global_search', true)); // always search on string field only
                 }
             }

--- a/src/DependencyInjection/Compiler/AddTemplatesCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AddTemplatesCompilerPass.php
@@ -27,7 +27,7 @@ class AddTemplatesCompilerPass implements CompilerPassInterface
     {
         $settings = $this->fixSettings($container);
         foreach ($container->findTaggedServiceIds('sonata.admin') as $id => $attributes) {
-            if (!isset($attributes[0]['manager_type']) || $attributes[0]['manager_type'] != 'doctrine_phpcr') {
+            if (!isset($attributes[0]['manager_type']) || 'doctrine_phpcr' != $attributes[0]['manager_type']) {
                 continue;
             }
 


### PR DESCRIPTION
I am targeting this branch, because this is BC.

Closes #524

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Require highest versions of phpcr/phpcr and phpcr/phpcr-utils
```

## Subject

A job with `COMPOSER_FLAGS="--prefer-lowest"` is failing because it require too much time for `composer update`

Also, `symfony-cmf/testing` v2.1 package is not compatible with current `2.x` (i guess)