### PR TITLE
Choice Type Compatibility SF3

### DIFF
--- a/src/Form/Type/Filter/ChoiceType.php
+++ b/src/Form/Type/Filter/ChoiceType.php
@@ -43,15 +43,16 @@ class ChoiceType extends BaseChoiceType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $choices = [
-            self::TYPE_CONTAINS => $this->translator->trans('label_type_contains', [], 'SonataAdminBundle'),
-            self::TYPE_NOT_CONTAINS => $this->translator->trans('label_type_not_contains', [], 'SonataAdminBundle'),
-            self::TYPE_EQUAL => $this->translator->trans('label_type_equals', [], 'SonataAdminBundle'),
-            self::TYPE_CONTAINS_WORDS => $this->translator->trans('label_type_contains_words', [], 'SonataDoctrinePHPCRAdmin'),
+            $this->translator->trans('label_type_contains', [], 'SonataAdminBundle') => self::TYPE_CONTAINS,
+            $this->translator->trans('label_type_not_contains', [], 'SonataAdminBundle') => self::TYPE_NOT_CONTAINS,
+            $this->translator->trans('label_type_equals', [], 'SonataAdminBundle') => self::TYPE_EQUAL,
+            $this->translator->trans('label_type_contains_words', [], 'SonataDoctrinePHPCRAdmin') => self::TYPE_CONTAINS_WORDS,
         ];
 
         $builder
             ->add('type', SymfonyChoiceType::class, [
                 'choices' => $choices,
+                'choices_as_values' => true,
                 'required' => false,
             ])
             ->add('value', $options['field_type'], array_merge(['required' => false], $options['field_options']))


### PR DESCRIPTION
Flip choices
Use choices_as_values for Symfony 2 compatibility

<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 2.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataDoctrinePhpcrAdminBundle/blob/2.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because compatible with Symfony 3.

Closes #462 and PR #463

## Changelog

```markdown
### Fixed
Form Type Filter ChoiceType Symfony 3 comptability
```

## Subject

Make Form Type Filter ChoiceType compatible with Symfony 3