### PR TITLE
Fix Child "_delete" does not exist.

### DIFF
--- a/src/Form/Listener/CollectionOrderListener.php
+++ b/src/Form/Listener/CollectionOrderListener.php
@@ -67,7 +67,7 @@ class CollectionOrderListener
 
         /** @var $item FormBuilder */
         foreach ($form->get($this->name) as $key => $item) {
-            if ($item->get('_delete')->getData()) {
+            if ($item->has('_delete') && $item->get('_delete')->getData()) {
                 // do not re-add a deleted child
                 continue;
             }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
If current role is not allowed to delete the item the `_delete` checkboxes are not added in items.
And when we submit the form we have `Child "_delete" does not exist.` error.

I am targeting this branch, because this is a patch with BC.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- `Child "_delete" does not exist` in Collection when we don't have delete permission
```
