### PR TITLE
Fix missing missing parameter extension test

### DIFF
--- a/tests/Unit/DependencyInjection/SonataDoctrinePHPCRAdminExtensionTest.php
+++ b/tests/Unit/DependencyInjection/SonataDoctrinePHPCRAdminExtensionTest.php
@@ -31,6 +31,10 @@ class SonataDoctrinePHPCRAdminExtensionTest extends AbstractExtensionTestCase
             'kernel.bundles',
             []
         );
+        $this->container->setParameter(
+            'sonata.admin.configuration.use_intl_templates',
+            false
+        );
         $this->load(['document_tree' => []]);
 
         $this->assertContainerBuilderHasParameter(


### PR DESCRIPTION
I've tried to add the `SonataAdminExtension` to `getContainerExtensions`, but there a couple of problems here with [the `load` method](https://github.com/SymfonyTest/SymfonyDependencyInjectionTest/blob/master/PhpUnit/AbstractExtensionTestCase.php#L48). 

First it is dependent on the order the extensions were declared, it should iterate the extensions first and call `prepend` and then iterate them again and call `load`. 

And then if you pass to the `load` method: `$this->load(['document_tree' => []]);`, both extension will try to load this configuration which is wrong.

So this is why I added `sonata.admin.configuration.use_intl_templates` parameter directly. 

Ref: https://github.com/SymfonyTest/SymfonyDependencyInjectionTest/issues/78