### PR TITLE
Allow custom sortOrder

### DIFF
--- a/tests/Unit/Datagrid/ProxyQueryTest.php
+++ b/tests/Unit/Datagrid/ProxyQueryTest.php
@@ -111,6 +111,25 @@ class ProxyQueryTest extends TestCase
         $this->assertSame('test', $res);
     }
 
+    public function testExecuteWithSortBy(): void
+    {
+        $qb = $this->createPartialMock(QueryBuilder::class, ['getQuery']);
+
+        $qb->expects($this->once())
+            ->method('getQuery')
+            ->willReturn($this->query);
+        $this->query->expects($this->once())
+            ->method('execute')
+            ->willReturn('test');
+
+        $pq = new ProxyQuery($qb, 'a');
+
+        $pq->setSortBy([], ['fieldName' => 'field']);
+        $pq->setSortOrder('ASC');
+        $res = $pq->execute();
+        $this->assertSame('test', $res);
+    }
+
     public function testGetAndSetDocumentManager(): void
     {
         $dm = $this->createMock(DocumentManager::class);


### PR DESCRIPTION
## Subject

<!-- Describe your Pull Request content here -->

Similar to https://github.com/sonata-project/SonataDoctrineORMAdminBundle/pull/997
I am targeting this branch, because BC, since the custom OrderBy was not handle at all.

## Changelog

```markdown
### Added
- The proxyQuery does now support custom `orderBy` set in `configureQuery` and apply them after the datagrid '_sort_by'.
```