### PR TITLE
Make filters behaviour more consistent with others ORM

### DIFF
--- a/src/Filter/BooleanFilter.php
+++ b/src/Filter/BooleanFilter.php
@@ -14,8 +14,10 @@ declare(strict_types=1);
 namespace Sonata\DoctrinePHPCRAdminBundle\Filter;
 
 use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
+use Sonata\AdminBundle\Form\Type\Filter\DefaultType;
 use Sonata\DoctrinePHPCRAdminBundle\Filter\Filter as BaseFilter;
 use Sonata\Form\Type\BooleanType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 
 class BooleanFilter extends BaseFilter
 {
@@ -44,7 +46,11 @@ class BooleanFilter extends BaseFilter
      */
     public function getDefaultOptions()
     {
-        return [];
+        return [
+            'field_type' => BooleanType::class,
+            'operator_type' => HiddenType::class,
+            'operator_options' => [],
+        ];
     }
 
     /**
@@ -52,11 +58,11 @@ class BooleanFilter extends BaseFilter
      */
     public function getRenderSettings()
     {
-        return ['sonata_type_filter_default', [
+        return [DefaultType::class, [
             'field_type' => $this->getFieldType(),
             'field_options' => $this->getFieldOptions(),
-            'operator_type' => 'hidden',
-            'operator_options' => [],
+            'operator_type' => $this->getOption('operator_type'),
+            'operator_options' => $this->getOption('operator_options'),
             'label' => $this->getLabel(),
         ]];
     }

--- a/src/Filter/CallbackFilter.php
+++ b/src/Filter/CallbackFilter.php
@@ -14,7 +14,10 @@ declare(strict_types=1);
 namespace Sonata\DoctrinePHPCRAdminBundle\Filter;
 
 use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
+use Sonata\AdminBundle\Form\Type\Filter\DefaultType;
 use Sonata\DoctrinePHPCRAdminBundle\Filter\Filter as BaseFilter;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 
 class CallbackFilter extends BaseFilter
 {
@@ -40,8 +43,8 @@ class CallbackFilter extends BaseFilter
     {
         return [
             'callback' => null,
-            'field_type' => 'Symfony\Component\Form\Extension\Core\Type\TextType',
-            'operator_type' => 'hidden',
+            'field_type' => TextType::class,
+            'operator_type' => HiddenType::class,
             'operator_options' => [],
         ];
     }
@@ -51,7 +54,7 @@ class CallbackFilter extends BaseFilter
      */
     public function getRenderSettings()
     {
-        return ['sonata_type_filter_default', [
+        return [DefaultType::class, [
             'field_type' => $this->getFieldType(),
             'field_options' => $this->getFieldOptions(),
             'operator_type' => $this->getOption('operator_type'),

--- a/src/Filter/DateFilter.php
+++ b/src/Filter/DateFilter.php
@@ -15,6 +15,7 @@ namespace Sonata\DoctrinePHPCRAdminBundle\Filter;
 
 use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
 use Sonata\AdminBundle\Form\Type\Filter\DateType;
+use Sonata\AdminBundle\Form\Type\Operator\DateOperatorType;
 
 class DateFilter extends Filter
 {
@@ -27,7 +28,7 @@ class DateFilter extends Filter
             return;
         }
 
-        $data['type'] = $data['type'] ?? DateType::TYPE_EQUAL;
+        $data['type'] = $data['type'] ?? DateOperatorType::TYPE_EQUAL;
 
         $where = $this->getWhere($proxyQuery);
 
@@ -35,31 +36,31 @@ class DateFilter extends Filter
         $to = new \DateTime($from->format('Y-m-d').' +86399 seconds'); // 23 hours 59 minutes 59 seconds
 
         switch ($data['type']) {
-            case DateType::TYPE_GREATER_EQUAL:
+            case DateOperatorType::TYPE_GREATER_EQUAL:
                 $where->gte()->field('a.'.$field)->literal($from);
 
                 break;
-            case DateType::TYPE_GREATER_THAN:
+            case DateOperatorType::TYPE_GREATER_THAN:
                 $where->gt()->field('a.'.$field)->literal($from);
 
                 break;
-            case DateType::TYPE_LESS_EQUAL:
+            case DateOperatorType::TYPE_LESS_EQUAL:
                 $where->lte()->field('a.'.$field)->literal($from);
 
                 break;
-            case DateType::TYPE_LESS_THAN:
+            case DateOperatorType::TYPE_LESS_THAN:
                 $where->lt()->field('a.'.$field)->literal($from);
 
                 break;
-            case DateType::TYPE_NULL:
+            case DateOperatorType::TYPE_NULL:
                 $where->eq()->field('a.'.$field)->literal(null);
 
                 break;
-            case DateType::TYPE_NOT_NULL:
+            case DateOperatorType::TYPE_NOT_NULL:
                 $where->neq()->field('a.'.$field)->literal(null);
 
                 break;
-            case DateType::TYPE_EQUAL:
+            case DateOperatorType::TYPE_EQUAL:
             default:
                 $where->andX()
                     ->gte()->field('a.'.$field)->literal($from)->end()
@@ -85,7 +86,7 @@ class DateFilter extends Filter
      */
     public function getRenderSettings()
     {
-        return ['sonata_type_filter_date', [
+        return [DateType::class, [
             'field_type' => $this->getFieldType(),
             'field_options' => $this->getFieldOptions(),
             'label' => $this->getLabel(),

--- a/src/Filter/NodeNameFilter.php
+++ b/src/Filter/NodeNameFilter.php
@@ -65,7 +65,7 @@ class NodeNameFilter extends Filter
      */
     public function getRenderSettings()
     {
-        return ['Sonata\DoctrinePHPCRAdminBundle\Form\Type\Filter\ChoiceType', [
+        return [ChoiceType::class, [
             'field_type' => $this->getFieldType(),
             'field_options' => $this->getFieldOptions(),
             'label' => $this->getLabel(),

--- a/src/Filter/NumberFilter.php
+++ b/src/Filter/NumberFilter.php
@@ -15,6 +15,7 @@ namespace Sonata\DoctrinePHPCRAdminBundle\Filter;
 
 use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
 use Sonata\AdminBundle\Form\Type\Filter\NumberType;
+use Sonata\AdminBundle\Form\Type\Operator\NumberOperatorType;
 
 class NumberFilter extends Filter
 {
@@ -33,23 +34,23 @@ class NumberFilter extends Filter
         $value = $data['value'];
 
         switch ($type) {
-            case NumberType::TYPE_GREATER_EQUAL:
+            case NumberOperatorType::TYPE_GREATER_EQUAL:
                 $where->gte()->field('a.'.$field)->literal($value);
 
                 break;
-            case NumberType::TYPE_GREATER_THAN:
+            case NumberOperatorType::TYPE_GREATER_THAN:
                 $where->gt()->field('a.'.$field)->literal($value);
 
                 break;
-            case NumberType::TYPE_LESS_EQUAL:
+            case NumberOperatorType::TYPE_LESS_EQUAL:
                 $where->lte()->field('a.'.$field)->literal($value);
 
                 break;
-            case NumberType::TYPE_LESS_THAN:
+            case NumberOperatorType::TYPE_LESS_THAN:
                 $where->lt()->field('a.'.$field)->literal($value);
 
                 break;
-            case NumberType::TYPE_EQUAL:
+            case NumberOperatorType::TYPE_EQUAL:
             default:
                 $where->eq()->field('a.'.$field)->literal($value);
         }
@@ -71,7 +72,7 @@ class NumberFilter extends Filter
      */
     public function getRenderSettings()
     {
-        return ['sonata_type_filter_number', [
+        return [NumberType::class, [
             'field_type' => $this->getFieldType(),
             'field_options' => $this->getFieldOptions(),
             'label' => $this->getLabel(),

--- a/tests/Unit/Filter/BooleanFilterTest.php
+++ b/tests/Unit/Filter/BooleanFilterTest.php
@@ -56,15 +56,15 @@ class BooleanFilterTest extends BaseTestCase
     public function getFilters()
     {
         return [
-            ['eq', BooleanType::TYPE_YES, true],
-            ['eq', BooleanType::TYPE_NO, false],
+            [BooleanType::TYPE_YES, true],
+            [BooleanType::TYPE_NO, false],
         ];
     }
 
     /**
      * @dataProvider getFilters
      */
-    public function testFilterSwitch($operatorMethod, $value, $expectedValue): void
+    public function testFilterSwitch(int $value, bool $expectedValue): void
     {
         $this->filter->filter(
             $this->proxyQuery,

--- a/tests/Unit/Filter/BooleanFilterTest.php
+++ b/tests/Unit/Filter/BooleanFilterTest.php
@@ -73,11 +73,13 @@ class BooleanFilterTest extends BaseTestCase
             ['type' => '', 'value' => $value]
         );
 
+        $op = $this->qbTester->getNode('where.constraint');
         $opDynamic = $this->qbTester->getNode('where.constraint.operand_dynamic');
         $opStatic = $this->qbTester->getNode('where.constraint.operand_static');
 
         $this->assertSame('a', $opDynamic->getAlias());
         $this->assertSame('somefield', $opDynamic->getField());
+        $this->assertSame('jcr.operator.equal.to', $op->getOperator());
         $this->assertSame($expectedValue, $opStatic->getValue());
 
         $this->assertTrue($this->filter->isActive());

--- a/tests/Unit/Filter/CallBackFilterTest.php
+++ b/tests/Unit/Filter/CallBackFilterTest.php
@@ -88,11 +88,13 @@ class CallBackFilterTest extends BaseTestCase
 
         $filter->filter($this->proxyQuery, null, 'somefield', ['type' => '', 'value' => 'somevalue']);
 
+        $op = $this->qbTester->getNode('where.constraint');
         $opDynamic = $this->qbTester->getNode('where.constraint.operand_dynamic');
         $opStatic = $this->qbTester->getNode('where.constraint.operand_static');
 
         $this->assertSame('a', $opDynamic->getAlias());
         $this->assertSame('somefield', $opDynamic->getField());
+        $this->assertSame('jcr.operator.equal.to', $op->getOperator());
         $this->assertSame('somevalue', $opStatic->getValue());
 
         $this->assertTrue($filter->isActive());

--- a/tests/Unit/Filter/ChoiceFilterTest.php
+++ b/tests/Unit/Filter/ChoiceFilterTest.php
@@ -13,11 +13,16 @@ declare(strict_types=1);
 
 namespace Sonata\DoctrinePHPCRAdminBundle\Tests\Unit\Filter;
 
-use Sonata\AdminBundle\Form\Type\Filter\ChoiceType;
+use Sonata\AdminBundle\Form\Type\Operator\EqualOperatorType;
 use Sonata\DoctrinePHPCRAdminBundle\Filter\ChoiceFilter;
 
 class ChoiceFilterTest extends BaseTestCase
 {
+    /**
+     * @var ChoiceFilter
+     */
+    private $filter;
+
     public function setUp(): void
     {
         parent::setUp();
@@ -40,7 +45,7 @@ class ChoiceFilterTest extends BaseTestCase
 
     public function testFilterEmptyArrayDataSpecifiedType(): void
     {
-        $res = $this->filter->filter($this->proxyQuery, null, 'somefield', ['type' => ChoiceType::TYPE_EQUAL]);
+        $res = $this->filter->filter($this->proxyQuery, null, 'somefield', ['type' => EqualOperatorType::TYPE_EQUAL]);
         $this->assertNull($res);
         $this->assertFalse($this->filter->isActive());
     }
@@ -62,23 +67,22 @@ class ChoiceFilterTest extends BaseTestCase
      */
     public function testFilterEmptyArrayDataWithMeaninglessValue($value): void
     {
-        $this->filter->filter($this->proxyQuery, null, 'somefield', ['type' => ChoiceType::TYPE_EQUAL, 'value' => $value]);
+        $this->filter->filter($this->proxyQuery, null, 'somefield', ['type' => EqualOperatorType::TYPE_EQUAL, 'value' => $value]);
         $this->assertFalse($this->filter->isActive());
     }
 
     public function getFilters()
     {
         return [
-            ['eq', ChoiceType::TYPE_EQUAL],
-            ['textSearch', ChoiceType::TYPE_NOT_CONTAINS, '* -somevalue'],
-            ['like', ChoiceType::TYPE_CONTAINS, '%somevalue%'],
+            [EqualOperatorType::TYPE_EQUAL],
+            [EqualOperatorType::TYPE_NOT_EQUAL],
         ];
     }
 
     /**
      * @dataProvider getFilters
      */
-    public function testFilterSwitch($operatorMethod, $choiceType, $expectedValue = 'somevalue'): void
+    public function testFilterSwitch(int $choiceType): void
     {
         $this->proxyQuery->expects($this->once())
             ->method('getQueryBuilder')
@@ -97,118 +101,7 @@ class ChoiceFilterTest extends BaseTestCase
     {
         return [
             [[
-                'choiceType' => ChoiceType::TYPE_NOT_CONTAINS,
-                'value' => 'somevalue',
-                'qbNodeCount' => 6,
-                'assertPaths' => [
-                    'where.constraint.constraint[0].constraint.operand_dynamic' => [
-                        'getAlias' => 'a',
-                        'getField' => 'somefield',
-                    ],
-                    'where.constraint.constraint[0].constraint.operand_static' => [
-                        'getValue' => '%somevalue%',
-                    ],
-                ],
-            ]],
-            [[
-                'choiceType' => ChoiceType::TYPE_NOT_CONTAINS,
-                'value' => ['somevalue', 'somevalue'],
-                'qbNodeCount' => 10,
-                'assertPaths' => [
-                    'where.constraint.constraint.constraint.operand_dynamic' => [
-                        'getAlias' => 'a',
-                        'getField' => 'somefield',
-                    ],
-                    'where.constraint.constraint.constraint.operand_static' => [
-                        'getValue' => '%somevalue%',
-                    ],
-                    'where.constraint.constraint[1].constraint.operand_dynamic' => [
-                        'getAlias' => 'a',
-                        'getField' => 'somefield',
-                    ],
-                    'where.constraint.constraint[1].constraint.operand_static' => [
-                        'getValue' => '%somevalue%',
-                    ],
-                ],
-            ]],
-            [[
-                'choiceType' => ChoiceType::TYPE_CONTAINS,
-                'value' => 'somevalue',
-                'qbNodeCount' => 5,
-                'assertPaths' => [
-                    'where.constraint.constraint.operand_dynamic' => [
-                        'getAlias' => 'a',
-                        'getField' => 'somefield',
-                    ],
-                    'where.constraint.constraint.operand_static' => [
-                        'getValue' => '%somevalue%',
-                    ],
-                    'where.constraint.constraint.operand_static' => [
-                        'getValue' => '%somevalue%',
-                    ],
-                ],
-            ]],
-            [[
-                'choiceType' => ChoiceType::TYPE_CONTAINS,
-                'value' => ['somevalue', 'somevalue'],
-                'qbNodeCount' => 8,
-                'assertPaths' => [
-                    'where.constraint.constraint.operand_dynamic' => [
-                        'getAlias' => 'a',
-                        'getField' => 'somefield',
-                    ],
-                    'where.constraint.constraint.operand_static' => [
-                        'getValue' => '%somevalue%',
-                    ],
-                    'where.constraint.constraint[1].operand_dynamic' => [
-                        'getAlias' => 'a',
-                        'getField' => 'somefield',
-                    ],
-                    'where.constraint.constraint[1].operand_static' => [
-                        'getValue' => '%somevalue%',
-                    ],
-                ],
-            ]],
-            [[
-                'choiceType' => ChoiceType::TYPE_CONTAINS,
-                'value' => 'somevalue',
-                'qbNodeCount' => 5,
-                'assertPaths' => [
-                    'where.constraint.constraint.operand_dynamic' => [
-                        'getAlias' => 'a',
-                        'getField' => 'somefield',
-                    ],
-                    'where.constraint.constraint.operand_static' => [
-                        'getValue' => '%somevalue%',
-                    ],
-                    'where.constraint.constraint.operand_static' => [
-                        'getValue' => '%somevalue%',
-                    ],
-                ],
-            ]],
-            [[
-                'choiceType' => ChoiceType::TYPE_CONTAINS,
-                'value' => ['somevalue', 'somevalue'],
-                'qbNodeCount' => 8,
-                'assertPaths' => [
-                    'where.constraint.constraint.operand_dynamic' => [
-                        'getAlias' => 'a',
-                        'getField' => 'somefield',
-                    ],
-                    'where.constraint.constraint.operand_static' => [
-                        'getValue' => '%somevalue%',
-                    ],
-                    'where.constraint.constraint[1].operand_dynamic' => [
-                        'getAlias' => 'a',
-                        'getField' => 'somefield',
-                    ],
-                    'where.constraint.constraint[1].operand_static' => [
-                        'getValue' => '%somevalue%',
-                    ],
-                ],
-            ]],
-            [[
-                'choiceType' => ChoiceType::TYPE_EQUAL,
+                'choiceType' => EqualOperatorType::TYPE_NOT_EQUAL,
                 'value' => 'somevalue',
                 'qbNodeCount' => 5,
                 'assertPaths' => [
@@ -219,13 +112,115 @@ class ChoiceFilterTest extends BaseTestCase
                     'where.constraint.constraint.operand_static' => [
                         'getValue' => 'somevalue',
                     ],
+                ],
+            ]],
+            [[
+                'choiceType' => EqualOperatorType::TYPE_NOT_EQUAL,
+                'value' => ['somevalue', 'somevalue'],
+                'qbNodeCount' => 8,
+                'assertPaths' => [
+                    'where.constraint.constraint.operand_dynamic' => [
+                        'getAlias' => 'a',
+                        'getField' => 'somefield',
+                    ],
+                    'where.constraint.constraint.operand_static' => [
+                        'getValue' => 'somevalue',
+                    ],
+                    'where.constraint.constraint[1].operand_dynamic' => [
+                        'getAlias' => 'a',
+                        'getField' => 'somefield',
+                    ],
+                    'where.constraint.constraint[1].operand_static' => [
+                        'getValue' => 'somevalue',
+                    ],
+                ],
+            ]],
+            [[
+                'choiceType' => EqualOperatorType::TYPE_EQUAL,
+                'value' => 'somevalue',
+                'qbNodeCount' => 5,
+                'assertPaths' => [
+                    'where.constraint.constraint.operand_dynamic' => [
+                        'getAlias' => 'a',
+                        'getField' => 'somefield',
+                    ],
                     'where.constraint.constraint.operand_static' => [
                         'getValue' => 'somevalue',
                     ],
                 ],
             ]],
             [[
-                'choiceType' => ChoiceType::TYPE_EQUAL,
+                'choiceType' => EqualOperatorType::TYPE_EQUAL,
+                'value' => ['somevalue', 'somevalue'],
+                'qbNodeCount' => 8,
+                'assertPaths' => [
+                    'where.constraint.constraint.operand_dynamic' => [
+                        'getAlias' => 'a',
+                        'getField' => 'somefield',
+                    ],
+                    'where.constraint.constraint.operand_static' => [
+                        'getValue' => 'somevalue',
+                    ],
+                    'where.constraint.constraint[1].operand_dynamic' => [
+                        'getAlias' => 'a',
+                        'getField' => 'somefield',
+                    ],
+                    'where.constraint.constraint[1].operand_static' => [
+                        'getValue' => 'somevalue',
+                    ],
+                ],
+            ]],
+            [[
+                'choiceType' => EqualOperatorType::TYPE_EQUAL,
+                'value' => 'somevalue',
+                'qbNodeCount' => 5,
+                'assertPaths' => [
+                    'where.constraint.constraint.operand_dynamic' => [
+                        'getAlias' => 'a',
+                        'getField' => 'somefield',
+                    ],
+                    'where.constraint.constraint.operand_static' => [
+                        'getValue' => 'somevalue',
+                    ],
+                ],
+            ]],
+            [[
+                'choiceType' => EqualOperatorType::TYPE_EQUAL,
+                'value' => ['somevalue', 'somevalue'],
+                'qbNodeCount' => 8,
+                'assertPaths' => [
+                    'where.constraint.constraint.operand_dynamic' => [
+                        'getAlias' => 'a',
+                        'getField' => 'somefield',
+                    ],
+                    'where.constraint.constraint.operand_static' => [
+                        'getValue' => 'somevalue',
+                    ],
+                    'where.constraint.constraint[1].operand_dynamic' => [
+                        'getAlias' => 'a',
+                        'getField' => 'somefield',
+                    ],
+                    'where.constraint.constraint[1].operand_static' => [
+                        'getValue' => 'somevalue',
+                    ],
+                ],
+            ]],
+            [[
+                'choiceType' => EqualOperatorType::TYPE_EQUAL,
+                'value' => 'somevalue',
+                'qbNodeCount' => 5,
+                'assertPaths' => [
+                    'where.constraint.constraint.operand_dynamic' => [
+                        'getAlias' => 'a',
+                        'getField' => 'somefield',
+                    ],
+                    'where.constraint.constraint.operand_static' => [
+                        'getValue' => 'somevalue',
+                    ],
+                ],
+            ]],
+            [[
+                'choiceType' => EqualOperatorType::TYPE_EQUAL,
                 'value' => ['somevalue', 'somevalue'],
                 'qbNodeCount' => 8,
                 'assertPaths' => [

--- a/tests/Unit/Filter/DateFilterTest.php
+++ b/tests/Unit/Filter/DateFilterTest.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\DoctrinePHPCRAdminBundle\Tests\Unit\Filter;
 
-use Sonata\AdminBundle\Form\Type\Filter\DateType;
+use Sonata\AdminBundle\Form\Type\Operator\DateOperatorType;
 use Sonata\DoctrinePHPCRAdminBundle\Filter\DateFilter;
 
 class DateFilterTest extends BaseTestCase
@@ -44,13 +44,13 @@ class DateFilterTest extends BaseTestCase
     public function getFilters()
     {
         return [
-            ['gte', DateType::TYPE_GREATER_EQUAL],
-            ['gt', DateType::TYPE_GREATER_THAN],
-            ['lte', DateType::TYPE_LESS_EQUAL],
-            ['lt', DateType::TYPE_LESS_THAN],
-            ['eq', DateType::TYPE_NULL, null],
-            ['neq', DateType::TYPE_NOT_NULL, null],
-            // test ChoiceTYPE::TYPE_EQUAL separately, special case.
+            ['gte', DateOperatorType::TYPE_GREATER_EQUAL],
+            ['gt', DateOperatorType::TYPE_GREATER_THAN],
+            ['lte', DateOperatorType::TYPE_LESS_EQUAL],
+            ['lt', DateOperatorType::TYPE_LESS_THAN],
+            ['eq', DateOperatorType::TYPE_NULL, null],
+            ['neq', DateOperatorType::TYPE_NOT_NULL, null],
+            // test DateOperatorType::TYPE_EQUAL separately, special case.
         ];
     }
 
@@ -95,7 +95,7 @@ class DateFilterTest extends BaseTestCase
             $this->proxyQuery,
             null,
             'somefield',
-            ['type' => DateType::TYPE_EQUAL, 'value' => $from]
+            ['type' => DateOperatorType::TYPE_EQUAL, 'value' => $from]
         );
 
         // FROM

--- a/tests/Unit/Filter/NodeNameFilterTest.php
+++ b/tests/Unit/Filter/NodeNameFilterTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\DoctrinePHPCRAdminBundle\Tests\Unit\Filter;
 
+use Sonata\AdminBundle\Form\Type\Operator\ContainsOperatorType;
 use Sonata\DoctrinePHPCRAdminBundle\Filter\NodeNameFilter;
 use Sonata\DoctrinePHPCRAdminBundle\Form\Type\Filter\ChoiceType;
 
@@ -26,7 +27,7 @@ class NodeNameFilterTest extends BaseTestCase
 
     public function getChoiceTypeForEmptyTests()
     {
-        return ChoiceType::TYPE_EQUAL;
+        return ContainsOperatorType::TYPE_EQUAL;
     }
 
     public function testFilterNullData(): void

--- a/tests/Unit/Filter/NumberFilterTest.php
+++ b/tests/Unit/Filter/NumberFilterTest.php
@@ -14,10 +14,16 @@ declare(strict_types=1);
 namespace Sonata\DoctrinePHPCRAdminBundle\Tests\Unit\Filter;
 
 use Sonata\AdminBundle\Form\Type\Filter\NumberType;
+use Sonata\AdminBundle\Form\Type\Operator\NumberOperatorType;
 use Sonata\DoctrinePHPCRAdminBundle\Filter\NumberFilter;
 
 class NumberFilterTest extends BaseTestCase
 {
+    /**
+     * @var NumberFilter
+     */
+    private $filter;
+
     public function setUp(): void
     {
         parent::setUp();
@@ -57,11 +63,11 @@ class NumberFilterTest extends BaseTestCase
     public function getFilters()
     {
         return [
-            ['gte', NumberType::TYPE_GREATER_EQUAL, 2],
-            ['gt', NumberType::TYPE_GREATER_THAN, 3],
-            ['lte', NumberType::TYPE_LESS_EQUAL, 4],
-            ['lt', NumberType::TYPE_LESS_THAN, 5],
-            ['eq', NumberType::TYPE_EQUAL, 6],
+            ['gte', NumberOperatorType::TYPE_GREATER_EQUAL, 2],
+            ['gt', NumberOperatorType::TYPE_GREATER_THAN, 3],
+            ['lte', NumberOperatorType::TYPE_LESS_EQUAL, 4],
+            ['lt', NumberOperatorType::TYPE_LESS_THAN, 5],
+            ['eq', NumberOperatorType::TYPE_EQUAL, 6],
             ['eq', 'default', 7],
         ];
     }

--- a/tests/Unit/Filter/NumberFilterTest.php
+++ b/tests/Unit/Filter/NumberFilterTest.php
@@ -63,19 +63,19 @@ class NumberFilterTest extends BaseTestCase
     public function getFilters()
     {
         return [
-            ['gte', NumberOperatorType::TYPE_GREATER_EQUAL, 2],
-            ['gt', NumberOperatorType::TYPE_GREATER_THAN, 3],
-            ['lte', NumberOperatorType::TYPE_LESS_EQUAL, 4],
-            ['lt', NumberOperatorType::TYPE_LESS_THAN, 5],
-            ['eq', NumberOperatorType::TYPE_EQUAL, 6],
-            ['eq', 'default', 7],
+            ['jcr.operator.greater.than.or.equal.to', NumberOperatorType::TYPE_GREATER_EQUAL, 2],
+            ['jcr.operator.greater.than', NumberOperatorType::TYPE_GREATER_THAN, 3],
+            ['jcr.operator.less.than.or.equal.to', NumberOperatorType::TYPE_LESS_EQUAL, 4],
+            ['jcr.operator.less.than', NumberOperatorType::TYPE_LESS_THAN, 5],
+            ['jcr.operator.equal.to', NumberOperatorType::TYPE_EQUAL, 6],
+            ['jcr.operator.equal.to', 'default', 7],
         ];
     }
 
     /**
      * @dataProvider getFilters
      */
-    public function testFilterSwitch($operatorMethod, $choiceType, $expectedValue = 'somevalue'): void
+    public function testFilterSwitch($operator, $choiceType, $expectedValue): void
     {
         $this->filter->filter(
             $this->proxyQuery,
@@ -84,11 +84,13 @@ class NumberFilterTest extends BaseTestCase
             ['type' => $choiceType, 'value' => $expectedValue]
         );
 
+        $op = $this->qbTester->getNode('where.constraint');
         $opDynamic = $this->qbTester->getNode('where.constraint.operand_dynamic');
         $opStatic = $this->qbTester->getNode('where.constraint.operand_static');
 
         $this->assertSame('a', $opDynamic->getAlias());
         $this->assertSame('somefield', $opDynamic->getField());
+        $this->assertSame($operator, $op->getOperator());
         $this->assertSame($expectedValue, $opStatic->getValue());
 
         $this->assertTrue($this->filter->isActive());


### PR DESCRIPTION
## Subject

I try to add consistency between SonataDoctrine bundle.

I am targeting this branch, because this should be only
- bugfix
- new feature
- remove deprecation

## Changelog

Will be updated.

```markdown
### Added
BooleanFilter 'operator_type' and 'operator_options' are now overridable

### Fixed
Fixed ChoiceFilter query
```

Todo:
- Update the NodeNameFilter: I don't know is this and the behaviour is weird. Here, https://github.com/sonata-project/SonataDoctrinePhpcrAdminBundle/blob/2.x/src/Filter/NodeNameFilter.php#L19, it does only implement 2 constants of the ChoiceType. But 4 are available. This would mean that using this filter with `NOT_CONTAINS` has the same effect that using it with `CONTAINS`.
- Update the StringFilter: https://github.com/sonata-project/SonataDoctrinePhpcrAdminBundle/blob/2.x/src/Filter/StringFilter.php

Both of these Filter use a custom ChoiceType: 
https://github.com/sonata-project/SonataDoctrinePhpcrAdminBundle/blob/2.x/src/Form/Type/Filter/ChoiceType.php
- This ChoiceType introduce a new constant 
- It's using the translator https://github.com/sonata-project/SonataDoctrinePhpcrAdminBundle/blob/2.x/src/Form/Type/Filter/ChoiceType.php#L46 which is deprecated in the original ChoiceType and will be removed in 4.0 https://github.com/sonata-project/SonataAdminBundle/blob/3.x/src/Form/Type/Filter/ChoiceType.php#L49

So what to do with this custom ChoiceType ? Dropping it in the next major ? Improving the SonataAdmin one and use it instead ?