### PR TITLE
Remove all special case for ChoiceFilter

### DIFF
--- a/src/Filter/ChoiceFilter.php
+++ b/src/Filter/ChoiceFilter.php
@@ -40,8 +40,8 @@ class ChoiceFilter extends Filter
             }
         }
 
-        // if values not set or "all" specified, do not do this filter
-        if (!$values || \in_array('all', $values, true)) {
+        // if values not set, do not do this filter
+        if (!$values) {
             return;
         }
 

--- a/tests/Unit/Filter/ChoiceFilterTest.php
+++ b/tests/Unit/Filter/ChoiceFilterTest.php
@@ -51,9 +51,8 @@ class ChoiceFilterTest extends BaseTestCase
             ['  '],
             [null],
             [false],
-            ['all'],
             [[]],
-            [['', 'all']],
+            [['', '   ']],
         ];
     }
 


### PR DESCRIPTION
## Subject

Same as https://github.com/sonata-project/SonataDoctrineORMAdminBundle/pull/1011

I am targeting this branch, because unfortunally this is a BC-break.

The `all` special case make no sens to me.
- It's not documented
- I can't filter by the `all` value if I have the `all` value in database.
- It does nothing, it's the same than an empty input.

## Changelog

```markdown
### Removed
- Special case for the `all` value in ChoiceFilter
```

If accepted, I'll make the PR for the other ORM bundle.