### PR TITLE
Stop using default SortBy

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "php": "^7.1",
         "doctrine/phpcr-bundle": "^1.3 || ^2.0",
         "doctrine/phpcr-odm": "^1.4.2 || ^2.0",
-        "sonata-project/admin-bundle": "^3.61",
+        "sonata-project/admin-bundle": "^3.63",
         "sonata-project/block-bundle": "^3.18.3",
         "symfony-cmf/resource-rest-bundle": "^1.0.1",
         "symfony-cmf/tree-browser-bundle": "^2.0",

--- a/src/Model/ModelManager.php
+++ b/src/Model/ModelManager.php
@@ -411,9 +411,8 @@ class ModelManager implements ModelManagerInterface
     public function getDefaultSortValues($class)
     {
         return [
-            '_sort_order' => 'ASC',
-            '_sort_by' => $this->getModelIdentifier($class),
             '_page' => 1,
+            '_per_page' => 25,
         ];
     }
 


### PR DESCRIPTION
## Subject

I am targeting this branch, because BC-break.

Same than https://github.com/sonata-project/SonataDoctrineORMAdminBundle/pull/1004

## Changelog

```markdown
### Added
- The modelManager getDefaultSortValues have a default `_per_page` value.

### Removed
- The modelManager getDefaultSortValues does not have default `_sort_by` value anymore.
```